### PR TITLE
Update build job conditions for non-PR triggers

### DIFF
--- a/.github/workflows/build-jetson.yml
+++ b/.github/workflows/build-jetson.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-jetson:
-    if: ${{ github.actor == 'retinify' }}
+    if: ${{ github.event_name != 'pull_request' || github.actor == 'retinify' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-tensorrt.yml
+++ b/.github/workflows/build-tensorrt.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-tensorrt:
-    if: ${{ github.actor == 'retinify' }}
+    if: ${{ github.event_name != 'pull_request' || github.actor == 'retinify' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Modify build job conditions to allow execution for non-pull request events while maintaining the existing restriction for the specified actor.