### PR TITLE
Add InitUndistortRectifyMap function and tests

### DIFF
--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -6,6 +6,7 @@
 #include "attributes.hpp"
 
 #include <array>
+#include <vector>
 
 namespace retinify
 {
@@ -227,4 +228,30 @@ RETINIFY_API auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
                                 Mat3x3d &R1, Mat3x3d &R2,                   //
                                 Mat3x4d &P1, Mat3x4d &P2,                   //
                                 Mat4x4d &Q) noexcept -> void;
+
+/// @brief
+/// Initialize undistort and rectify maps for image remapping.
+/// @param K
+/// Camera intrinsics
+/// @param D
+/// Distortion parameters
+/// @param R
+/// Rectification rotation
+/// @param P
+/// Projection matrix
+/// @param width
+/// Image width
+/// @param height
+/// Image height
+/// @param mapx
+/// Output map for x-coordinates
+/// @param mapy
+/// Output map for y-coordinates
+/// @return
+RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
+                                          const Mat3x3d &R,                         //
+                                          const Mat3x4d &P,                         //
+                                          int width, int height,                    //
+                                          std::vector<float> &mapx,                 //
+                                          std::vector<float> &mapy) -> void;
 } // namespace retinify

--- a/retinify/src/geometry.cpp
+++ b/retinify/src/geometry.cpp
@@ -4,21 +4,29 @@
 #include "retinify/geometry.hpp"
 
 #include <cmath>
-#include <numbers>
 
 namespace retinify
 {
-/// @brief Small epsilon constant for numerical stability.
-constexpr double kEPS = 1e-12;
+namespace
+{
+constexpr inline double kEpsilon = 1e-12;
+constexpr inline double kPi = 3.141592653589793;
 
-/// @brief Mathematical constant π (pi).
-constexpr double kPI = 3.14159265358979323846;
-
-/// @brief Clamp value into [lower, upper] (constexpr).
-constexpr double Clamp(double value, double lower, double upper) noexcept
+[[nodiscard]] constexpr double Clamp(double value, double lower, double upper) noexcept
 {
     return value < lower ? lower : (value > upper ? upper : value);
 }
+
+[[nodiscard]] constexpr double Square(double value) noexcept
+{
+    return value * value;
+}
+
+[[nodiscard]] double Reciprocal(double value, double fallback) noexcept
+{
+    return (std::fabs(value) > kEpsilon) ? (1.0 / value) : fallback;
+}
+} // namespace
 
 auto Identity() noexcept -> Mat3x3d
 {
@@ -30,48 +38,53 @@ auto Identity() noexcept -> Mat3x3d
 auto Determinant(const Mat3x3d &mat) noexcept -> double
 {
     // det(R) = r00(r11 r22 - r12 r21) - r01(r10 r22 - r12 r20) + r02(r10 r21 - r11 r20)
-    return mat[0][0] * (mat[1][1] * mat[2][2] - mat[1][2] * mat[2][1]) - //
-           mat[0][1] * (mat[1][0] * mat[2][2] - mat[1][2] * mat[2][0]) + //
-           mat[0][2] * (mat[1][0] * mat[2][1] - mat[1][1] * mat[2][0]);
+    const auto &row0 = mat[0];
+    const auto &row1 = mat[1];
+    const auto &row2 = mat[2];
+    return row0[0] * (row1[1] * row2[2] - row1[2] * row2[1]) - //
+           row0[1] * (row1[0] * row2[2] - row1[2] * row2[0]) + //
+           row0[2] * (row1[0] * row2[1] - row1[1] * row2[0]);
 }
 
 auto Transpose(const Mat3x3d &mat) noexcept -> Mat3x3d
 {
     // (R^T)_{ij} = R_{ji}
-    Mat3x3d matOut{};
+    Mat3x3d transposed{};
     for (int i = 0; i < 3; ++i)
     {
         for (int j = 0; j < 3; ++j)
         {
-            matOut[i][j] = mat[j][i];
+            transposed[i][j] = mat[j][i];
         }
     }
-    return matOut;
+    return transposed;
 }
 
 auto Multiply(const Mat3x3d &mat, const Vec3d &vec) noexcept -> Vec3d
 {
     // y = R x
-    Vec3d vecOut{};
+    Vec3d result{};
     for (int i = 0; i < 3; ++i)
     {
-        vecOut[i] = mat[i][0] * vec[0] + mat[i][1] * vec[1] + mat[i][2] * vec[2];
+        const auto &row = mat[i];
+        result[i] = row[0] * vec[0] + row[1] * vec[1] + row[2] * vec[2];
     }
-    return vecOut;
+    return result;
 }
 
 auto Multiply(const Mat3x3d &mat1, const Mat3x3d &mat2) noexcept -> Mat3x3d
 {
     // C = A B,  c_{ij} = Σ_k a_{ik} b_{kj}
-    Mat3x3d matOut{};
+    Mat3x3d result{};
     for (int i = 0; i < 3; ++i)
     {
+        const auto &row = mat1[i];
         for (int j = 0; j < 3; ++j)
         {
-            matOut[i][j] = mat1[i][0] * mat2[0][j] + mat1[i][1] * mat2[1][j] + mat1[i][2] * mat2[2][j];
+            result[i][j] = row[0] * mat2[0][j] + row[1] * mat2[1][j] + row[2] * mat2[2][j];
         }
     }
-    return matOut;
+    return result;
 }
 
 auto Scale(const Vec3d &vec, double scale) noexcept -> Vec3d
@@ -82,18 +95,19 @@ auto Scale(const Vec3d &vec, double scale) noexcept -> Vec3d
 auto Length(const Vec3d &vec) noexcept -> double
 {
     // ||v|| = sqrt(v·v)
-    return std::sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2]);
+    return std::sqrt(Square(vec[0]) + Square(vec[1]) + Square(vec[2]));
 }
 
 auto Normalize(const Vec3d &vec) noexcept -> Vec3d
 {
     // v / ||v||  (return zero if degenerate)
     const double n = Length(vec);
-    if (n < kEPS)
+    if (n < kEpsilon)
     {
         return {0.0, 0.0, 0.0};
     }
-    return {vec[0] / n, vec[1] / n, vec[2] / n};
+    const double inv = 1.0 / n;
+    return {vec[0] * inv, vec[1] * inv, vec[2] * inv};
 }
 
 auto Cross(const Vec3d &vec1, const Vec3d &vec2) noexcept -> Vec3d
@@ -112,13 +126,13 @@ auto Exp(const Vec3d &omega) noexcept -> Mat3x3d
     const double wx = omega[0];
     const double wy = omega[1];
     const double wz = omega[2];
-    const double thetaSquared = wx * wx + wy * wy + wz * wz;
+    const double thetaSquared = Square(wx) + Square(wy) + Square(wz);
 
-    Mat3x3d rotation{{{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}};
+    Mat3x3d rotation = Identity();
     double coefA = 0.0;
     double coefB = 0.0;
 
-    if (thetaSquared <= kEPS)
+    if (thetaSquared <= kEpsilon)
     {
         // coefA = 1 − θ^2/6 + θ^4/120
         // coefB = 1/2 − θ^2/24 + θ^4/720
@@ -134,7 +148,6 @@ auto Exp(const Vec3d &omega) noexcept -> Mat3x3d
         coefB = (1.0 - std::cos(theta)) / thetaSquared;
     }
 
-    // [ω]_x components
     const double w01 = -wz;
     const double w02 = wy;
     const double w10 = wz;
@@ -142,7 +155,6 @@ auto Exp(const Vec3d &omega) noexcept -> Mat3x3d
     const double w20 = -wy;
     const double w21 = wx;
 
-    // Precompute ωω^T terms
     const double wxx = wx * wx;
     const double wyy = wy * wy;
     const double wzz = wz * wz;
@@ -150,7 +162,6 @@ auto Exp(const Vec3d &omega) noexcept -> Mat3x3d
     const double wxz = wx * wz;
     const double wyz = wy * wz;
 
-    // R = I + coefA[ω]_x + coefB(ωω^T − θ^2 I)
     rotation[0][0] -= coefB * (wyy + wzz);
     rotation[0][1] += coefA * w01 + coefB * wxy;
     rotation[0][2] += coefA * w02 + coefB * wxz;
@@ -169,8 +180,8 @@ auto Exp(const Vec3d &omega) noexcept -> Mat3x3d
 auto Log(const Mat3x3d &rotation) noexcept -> Vec3d
 {
     // θ from trace: cosθ = (tr(R) − 1)/2
-    const double tr = rotation[0][0] + rotation[1][1] + rotation[2][2];
-    const double cosTheta = Clamp((tr - 1.0) * 0.5, -1.0, 1.0);
+    const double trace = rotation[0][0] + rotation[1][1] + rotation[2][2];
+    const double cosTheta = Clamp((trace - 1.0) * 0.5, -1.0, 1.0);
     const double theta = std::acos(cosTheta);
 
     // v = (R − R^T)∨ = 2 sinθ · n  (skew vector)
@@ -179,35 +190,33 @@ auto Log(const Mat3x3d &rotation) noexcept -> Vec3d
     const double vz = rotation[1][0] - rotation[0][1];
 
     // Small angle: ω ≈ 1/2 v (since sinθ ≈ θ)
-    if (theta < kEPS)
+    if (theta < kEpsilon)
     {
         return {0.5 * vx, 0.5 * vy, 0.5 * vz};
     }
 
     // Near π: sinθ ~ 0, use diagonal-based axis extraction.
-    if (std::fabs(kPI - theta) < 1e-6)
+    if (std::fabs(kPi - theta) < 1e-6)
     {
-        // n^2 from diagonal: n_x^2 = (R_xx + 1)/2, etc., clamped to [0,1].
         double ax = std::sqrt(std::max(0.0, (rotation[0][0] + 1.0) * 0.5));
         double ay = std::sqrt(std::max(0.0, (rotation[1][1] + 1.0) * 0.5));
         double az = std::sqrt(std::max(0.0, (rotation[2][2] + 1.0) * 0.5));
 
-        // Recover remaining components from off-diagonals using the largest axis to stabilize.
         if (ax >= ay && ax >= az)
         {
-            const double denom = 4.0 * std::max(ax, kEPS);
+            const double denom = 4.0 * std::max(ax, kEpsilon);
             ay = (rotation[0][1] + rotation[1][0]) / denom;
             az = (rotation[0][2] + rotation[2][0]) / denom;
         }
         else if (ay >= ax && ay >= az)
         {
-            const double denom = 4.0 * std::max(ay, kEPS);
+            const double denom = 4.0 * std::max(ay, kEpsilon);
             ax = (rotation[0][1] + rotation[1][0]) / denom;
             az = (rotation[1][2] + rotation[2][1]) / denom;
         }
         else
         {
-            const double denom = 4.0 * std::max(az, kEPS);
+            const double denom = 4.0 * std::max(az, kEpsilon);
             ax = (rotation[0][2] + rotation[2][0]) / denom;
             ay = (rotation[1][2] + rotation[2][1]) / denom;
         }
@@ -218,9 +227,9 @@ auto Log(const Mat3x3d &rotation) noexcept -> Vec3d
     }
 
     // General case: n = v / ||v||, ω = θ n
-    const double vnormSquared = vx * vx + vy * vy + vz * vz;
+    const double vnormSquared = Square(vx) + Square(vy) + Square(vz);
     const double vnorm = std::sqrt(std::max(0.0, vnormSquared));
-    if (vnorm < kEPS)
+    if (vnorm < kEpsilon)
     {
         return {0.0, 0.0, 0.0};
     }
@@ -230,8 +239,8 @@ auto Log(const Mat3x3d &rotation) noexcept -> Vec3d
 
 auto UndistortPoint(const Intrinsics &intrinsics, const Distortion &distortion, const Point2d &pixel) noexcept -> Point2d
 {
-    const double invFocalX = (intrinsics.fx != 0.0 ? 1.0 / intrinsics.fx : 1.0);
-    const double invFocalY = (intrinsics.fy != 0.0 ? 1.0 / intrinsics.fy : 1.0);
+    const double invFocalX = Reciprocal(intrinsics.fx, 1.0);
+    const double invFocalY = Reciprocal(intrinsics.fy, 1.0);
 
     const double normX = (pixel[0] - intrinsics.cx) * invFocalX;
     const double normY = (pixel[1] - intrinsics.cy) * invFocalY;
@@ -239,57 +248,51 @@ auto UndistortPoint(const Intrinsics &intrinsics, const Distortion &distortion, 
     double undistX = normX;
     double undistY = normY;
 
-    std::array<double, 14> distCoeffs = {};
-    distCoeffs[0] = distortion.k1; // k1
-    distCoeffs[1] = distortion.k2; // k2
-    distCoeffs[2] = distortion.p1; // p1
-    distCoeffs[3] = distortion.p2; // p2
-    distCoeffs[4] = distortion.k3; // k3
-    distCoeffs[5] = distortion.k4; // k4
-    distCoeffs[6] = distortion.k5; // k5
-    distCoeffs[7] = distortion.k6; // k6
-    distCoeffs[8] = 0.0;           // s1
-    distCoeffs[9] = 0.0;           // s2
-    distCoeffs[10] = 0.0;          // s3
-    distCoeffs[11] = 0.0;          // s4
-    distCoeffs[12] = 0.0;          // tau1
-    distCoeffs[13] = 0.0;          // tau2
-
     constexpr int kIterationCount = 5;
     for (int iter = 0; iter < kIterationCount; ++iter)
     {
-        double rSquared = undistX * undistX + undistY * undistY;
-        double radialNum = 1.0 + ((distCoeffs[7] * rSquared + distCoeffs[6]) * rSquared + distCoeffs[5]) * rSquared;
-        double radialDen = 1.0 + ((distCoeffs[4] * rSquared + distCoeffs[1]) * rSquared + distCoeffs[0]) * rSquared;
-        double distScale = (std::fabs(radialDen) > kEPS) ? (radialNum / radialDen) : 1.0;
-        if (distScale < 0)
+        // Brown-Conrady rational model inversion with r^2 = x^2 + y^2:
+        // radialScale = (1 + k4 r^2 + k5 r^4 + k6 r^6) / (1 + k1 r^2 + k2 r^4 + k3 r^6)
+        // Delta tangential = (2 p1 xy + p2 (r^2 + 2 x^2),
+        //                     p1 (r^2 + 2 y^2) + 2 p2 xy)
+        const double rSquared = Square(undistX) + Square(undistY);
+        const double rFourth = rSquared * rSquared;
+        const double rSixth = rFourth * rSquared;
+
+        const double radialNumerator = 1.0 + distortion.k4 * rSquared + distortion.k5 * rFourth + distortion.k6 * rSixth;
+        const double radialDenominator = 1.0 + distortion.k1 * rSquared + distortion.k2 * rFourth + distortion.k3 * rSixth;
+        const double radialScale = (std::fabs(radialDenominator) > kEpsilon) ? (radialNumerator / radialDenominator) : 1.0;
+        if (radialScale < 0.0)
         {
             undistX = normX;
             undistY = normY;
             break;
         }
-        double deltaX = 2 * distCoeffs[2] * undistX * undistY + distCoeffs[3] * (rSquared + 2 * undistX * undistX) + distCoeffs[8] * rSquared + distCoeffs[9] * rSquared * rSquared;
-        double deltaY = distCoeffs[2] * (rSquared + 2 * undistY * undistY) + 2 * distCoeffs[3] * undistX * undistY + distCoeffs[10] * rSquared + distCoeffs[11] * rSquared * rSquared;
-        undistX = (normX - deltaX) * distScale;
-        undistY = (normY - deltaY) * distScale;
+
+        const double twoXY = 2.0 * undistX * undistY;
+        const double xSquared = Square(undistX);
+        const double ySquared = Square(undistY);
+        const double deltaX = distortion.p1 * twoXY + distortion.p2 * (rSquared + 2.0 * xSquared);
+        const double deltaY = distortion.p1 * (rSquared + 2.0 * ySquared) + distortion.p2 * twoXY;
+
+        undistX = (normX - deltaX) * radialScale;
+        undistY = (normY - deltaY) * radialScale;
     }
     return {undistX, undistY};
 }
 
-namespace impl
+namespace
 {
 static auto ComputeRectifyingRotation(const Mat3x3d &rotation) noexcept -> Mat3x3d
 {
-    Vec3d omega = Log(rotation);
-    for (double &component : omega)
-    {
-        component *= -0.5;
-    }
-    return Exp(omega);
+    // Split relative rotation equally: R_rect = exp(-0.5 * log(R))
+    const Vec3d omega = Log(rotation);
+    return Exp(Scale(omega, -0.5));
 }
 
 static auto DetermineDominantAxis(const Vec3d &translation) noexcept -> int
 {
+    // argmax_i |T_i|
     return (std::fabs(translation[0]) > std::fabs(translation[1])) ? 0 : 1;
 }
 
@@ -302,12 +305,13 @@ static auto BuildAxisVector(int idx, double direction) noexcept -> Vec3d
 
 static auto ComputeBaselineAlignment(const Vec3d &translation, int axisIdx) noexcept -> Mat3x3d
 {
+    // Rotate translation onto +/- e_axis using axis = T x target, angle = acos(|T_axis| / ||T||)
     const double component = translation[axisIdx];
     const double length = Length(translation);
-    const Vec3d target = BuildAxisVector(axisIdx, component > 0.0 ? 1.0 : -1.0);
+    const Vec3d target = BuildAxisVector(axisIdx, component >= 0.0 ? 1.0 : -1.0);
     const Vec3d cross = Cross(translation, target);
     const double crossLength = Length(cross);
-    if (crossLength <= 0.0 || length <= 0.0)
+    if (crossLength <= kEpsilon || length <= kEpsilon)
     {
         return Identity();
     }
@@ -320,18 +324,21 @@ static auto ComputeBaselineAlignment(const Vec3d &translation, int axisIdx) noex
 static auto ComputePrincipalPoint(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rectifiedRotation, //
                                   double newFocalLength, double width, double height) noexcept -> Point2d
 {
-    const Point2d corners[4] = {{0.0, 0.0}, {width - 1.0, 0.0}, {0.0, height - 1.0}, {width - 1.0, height - 1.0}};
+    // Principal shift: c = (w-1, h-1)/2 - f * average( rectified_xy / rectified_z ) over undistorted corners
+    const std::array<Point2d, 4> corners{Point2d{0.0, 0.0}, Point2d{width - 1.0, 0.0}, Point2d{0.0, height - 1.0}, Point2d{width - 1.0, height - 1.0}};
+
     double accumulatedX = 0.0;
     double accumulatedY = 0.0;
     for (const auto &corner : corners)
     {
-        const Point2d undistortedPoint2D = UndistortPoint(intrinsics, distortion, corner);
-        const Vec3d undistortedPoint3D{undistortedPoint2D[0], undistortedPoint2D[1], 1.0};
-        const Vec3d rectifiedPoint3D = Multiply(rectifiedRotation, undistortedPoint3D);
-        const double inverseDepth = (std::fabs(rectifiedPoint3D[2]) > kEPS) ? (1.0 / rectifiedPoint3D[2]) : 1.0;
-        accumulatedX += newFocalLength * (rectifiedPoint3D[0] * inverseDepth);
-        accumulatedY += newFocalLength * (rectifiedPoint3D[1] * inverseDepth);
+        const Point2d undistorted2D = UndistortPoint(intrinsics, distortion, corner);
+        const Vec3d undistorted3D{undistorted2D[0], undistorted2D[1], 1.0};
+        const Vec3d rectifiedPoint = Multiply(rectifiedRotation, undistorted3D);
+        const double inverseDepth = Reciprocal(rectifiedPoint[2], 1.0);
+        accumulatedX += newFocalLength * rectifiedPoint[0] * inverseDepth;
+        accumulatedY += newFocalLength * rectifiedPoint[1] * inverseDepth;
     }
+
     const double halfWidth = (width - 1.0) * 0.5;
     const double halfHeight = (height - 1.0) * 0.5;
     return {halfWidth - accumulatedX * 0.25, halfHeight - accumulatedY * 0.25};
@@ -339,15 +346,16 @@ static auto ComputePrincipalPoint(const Intrinsics &intrinsics, const Distortion
 
 static auto BuildProjectionMatrix(double focal, const Point2d &principal) noexcept -> Mat3x4d
 {
-    Mat3x4d projection = Mat3x4d{};
+    // P = [[f, 0, cx, 0], [0, f, cy, 0], [0, 0, 1, 0]]
+    Mat3x4d projection{};
     projection[0][0] = focal;
-    projection[1][1] = focal;
     projection[0][2] = principal[0];
+    projection[1][1] = focal;
     projection[1][2] = principal[1];
     projection[2][2] = 1.0;
     return projection;
 }
-} // namespace impl
+} // namespace
 
 auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
                    const Intrinsics &K2, const Distortion &D2, //
@@ -357,27 +365,29 @@ auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
                    Mat3x4d &P1, Mat3x4d &P2,                   //
                    Mat4x4d &Q) noexcept -> void
 {
-    const Mat3x3d rectifyingRotation = impl::ComputeRectifyingRotation(R);
+    // Stereo rectification: R1 = R_align R_rect^T, R2 = R_align R_rect,
+    // share focal f = 0.5 * ((fx1+fx2) if axis=y else (fy1+fy2)), and set disparity scale via baseline
+    const Mat3x3d rectifyingRotation = ComputeRectifyingRotation(R);
     const Vec3d rotatedTranslation = Multiply(rectifyingRotation, T);
-    const int axisIdx = impl::DetermineDominantAxis(rotatedTranslation);
-    const Mat3x3d baselineAlignment = impl::ComputeBaselineAlignment(rotatedTranslation, axisIdx);
+    const int axisIdx = DetermineDominantAxis(rotatedTranslation);
+    const Mat3x3d baselineAlignment = ComputeBaselineAlignment(rotatedTranslation, axisIdx);
 
     const Mat3x3d rotationTranspose = Transpose(rectifyingRotation);
     R1 = Multiply(baselineAlignment, rotationTranspose);
     R2 = Multiply(baselineAlignment, rectifyingRotation);
 
     const Vec3d rectifiedTranslation = Multiply(R2, T);
-    const double newFocalScale = 0.5; // newImgSize defaults to imageSize -> ratio = 0.5
+    const double newFocalScale = 0.5;
     const double newFocalLength = (axisIdx == 0) ? (K1.fy + K2.fy) * newFocalScale : (K1.fx + K2.fx) * newFocalScale;
 
-    const Point2d principal0 = impl::ComputePrincipalPoint(K1, D1, R1, newFocalLength, static_cast<double>(width), static_cast<double>(height));
-    const Point2d principal1 = impl::ComputePrincipalPoint(K2, D2, R2, newFocalLength, static_cast<double>(width), static_cast<double>(height));
-    const double ccx = 0.5 * (principal0[0] + principal1[0]);
-    const double ccy = 0.5 * (principal0[1] + principal1[1]);
-    const Point2d principalAvg{ccx, ccy};
+    const Point2d principal1 = ComputePrincipalPoint(K1, D1, R1, newFocalLength, static_cast<double>(width), static_cast<double>(height));
+    const Point2d principal2 = ComputePrincipalPoint(K2, D2, R2, newFocalLength, static_cast<double>(width), static_cast<double>(height));
+    const double cxAvg = 0.5 * (principal1[0] + principal2[0]);
+    const double cyAvg = 0.5 * (principal1[1] + principal2[1]);
+    const Point2d principalAvg{cxAvg, cyAvg};
 
-    P1 = impl::BuildProjectionMatrix(newFocalLength, principalAvg);
-    P2 = impl::BuildProjectionMatrix(newFocalLength, principalAvg);
+    P1 = BuildProjectionMatrix(newFocalLength, principalAvg);
+    P2 = BuildProjectionMatrix(newFocalLength, principalAvg);
 
     const double baselineComponent = (axisIdx == 0) ? rectifiedTranslation[0] : rectifiedTranslation[1];
     const double translationOffset = baselineComponent * newFocalLength;
@@ -396,7 +406,64 @@ auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
     Q[0][3] = -principalAvg[0];
     Q[1][3] = -principalAvg[1];
     Q[2][3] = newFocalLength;
-    Q[3][2] = (std::fabs(baselineComponent) > kEPS) ? (-1.0 / baselineComponent) : 0.0;
+    Q[3][2] = (std::fabs(baselineComponent) > kEpsilon) ? (-1.0 / baselineComponent) : 0.0;
     Q[3][3] = 0.0;
+}
+
+auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
+                             const Mat3x3d &R,                         //
+                             const Mat3x4d &P,                         //
+                             int width, int height,                    //
+                             std::vector<float> &mapx,                 //
+                             std::vector<float> &mapy) -> void
+{
+    const std::size_t mapWidth = static_cast<std::size_t>(width);
+    const std::size_t mapHeight = static_cast<std::size_t>(height);
+    const std::size_t mapSize = mapWidth * mapHeight;
+    mapx.resize(mapSize);
+    mapy.resize(mapSize);
+
+    const Mat3x3d rotationInverse = Transpose(R);
+    const auto &projRow0 = P[0];
+    const auto &projRow1 = P[1];
+    const double invRectifiedFocalX = Reciprocal(projRow0[0], 0.0);
+    const double invRectifiedFocalY = Reciprocal(projRow1[1], 0.0);
+    const double rectifiedPrincipalX = projRow0[2];
+    const double rectifiedPrincipalY = projRow1[2];
+
+    for (int v = 0; v < height; ++v)
+    {
+        const double rectifiedY = (static_cast<double>(v) - rectifiedPrincipalY) * invRectifiedFocalY;
+        for (int u = 0; u < width; ++u)
+        {
+            const double rectifiedX = (static_cast<double>(u) - rectifiedPrincipalX) * invRectifiedFocalX;
+            const Vec3d rectifiedPoint{rectifiedX, rectifiedY, 1.0};
+            const Vec3d cameraPoint = Multiply(rotationInverse, rectifiedPoint);
+
+            const double inverseDepth = Reciprocal(cameraPoint[2], 0.0);
+            const double normalizedX = cameraPoint[0] * inverseDepth;
+            const double normalizedY = cameraPoint[1] * inverseDepth;
+
+            const double radiusSquared = Square(normalizedX) + Square(normalizedY);
+            const double radiusFourth = radiusSquared * radiusSquared;
+            const double radiusSixth = radiusFourth * radiusSquared;
+            const double radialNumerator = 1.0 + D.k1 * radiusSquared + D.k2 * radiusFourth + D.k3 * radiusSixth;
+            const double radialDenominator = 1.0 + D.k4 * radiusSquared + D.k5 * radiusFourth + D.k6 * radiusSixth;
+            const double radialScale = (std::fabs(radialDenominator) > kEpsilon) ? (radialNumerator / radialDenominator) : 1.0;
+
+            const double twoNormalizedXY = 2.0 * normalizedX * normalizedY;
+            const double normalizedXSquared = Square(normalizedX);
+            const double normalizedYSquared = Square(normalizedY);
+
+            const double distortedNormalizedX = normalizedX * radialScale + D.p1 * twoNormalizedXY + D.p2 * (radiusSquared + 2.0 * normalizedXSquared);
+            const double distortedNormalizedY = normalizedY * radialScale + D.p1 * (radiusSquared + 2.0 * normalizedYSquared) + D.p2 * twoNormalizedXY;
+
+            const double uDistorted = K.fx * distortedNormalizedX + K.skew * distortedNormalizedY + K.cx;
+            const double vDistorted = K.fy * distortedNormalizedY + K.cy;
+            const std::size_t idx = static_cast<std::size_t>(v) * mapWidth + static_cast<std::size_t>(u);
+            mapx[idx] = static_cast<float>(uDistorted);
+            mapy[idx] = static_cast<float>(vDistorted);
+        }
+    }
 }
 } // namespace retinify

--- a/retinify/tests/geometry_test.cpp
+++ b/retinify/tests/geometry_test.cpp
@@ -9,10 +9,7 @@
 
 namespace retinify
 {
-constexpr double kTol = 1e-9;
-constexpr double kOrthonormalTol = 1e-7;
-constexpr double kRectifyTol = 1e-8;
-constexpr double kMinTranslationTol = 1e-12;
+constexpr double kTol = 1e-12;
 
 void ExpectMatrixNear(const retinify::Mat3x3d &lhs, const retinify::Mat3x3d &rhs, double tol)
 {
@@ -20,8 +17,7 @@ void ExpectMatrixNear(const retinify::Mat3x3d &lhs, const retinify::Mat3x3d &rhs
     {
         for (int columnIndex = 0; columnIndex < 3; ++columnIndex)
         {
-            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol)
-                << "entry(" << rowIndex << "," << columnIndex << ")";
+            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol) << "entry(" << rowIndex << "," << columnIndex << ")";
         }
     }
 }
@@ -30,8 +26,7 @@ void ExpectVectorNear(const retinify::Vec3d &lhs, const retinify::Vec3d &rhs, do
 {
     for (int componentIndex = 0; componentIndex < 3; ++componentIndex)
     {
-        EXPECT_NEAR(lhs[componentIndex], rhs[componentIndex], tol)
-            << "entry(" << componentIndex << ")";
+        EXPECT_NEAR(lhs[componentIndex], rhs[componentIndex], tol) << "entry(" << componentIndex << ")";
     }
 }
 
@@ -49,8 +44,7 @@ void ExpectMatrix34Near(const retinify::Mat3x4d &lhs, const retinify::Mat3x4d &r
     {
         for (int columnIndex = 0; columnIndex < 4; ++columnIndex)
         {
-            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol)
-                << "entry(" << rowIndex << "," << columnIndex << ")";
+            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol) << "entry(" << rowIndex << "," << columnIndex << ")";
         }
     }
 }
@@ -61,8 +55,7 @@ void ExpectMatrix44Near(const retinify::Mat4x4d &lhs, const retinify::Mat4x4d &r
     {
         for (int columnIndex = 0; columnIndex < 4; ++columnIndex)
         {
-            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol)
-                << "entry(" << rowIndex << "," << columnIndex << ")";
+            EXPECT_NEAR(lhs[rowIndex][columnIndex], rhs[rowIndex][columnIndex], tol) << "entry(" << rowIndex << "," << columnIndex << ")";
         }
     }
 }
@@ -247,19 +240,7 @@ TEST(GeometryTest, StereoRectifyIdealRig)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(primaryIntrinsics,
-                  noDistortion,
-                  secondaryIntrinsics,
-                  noDistortion,
-                  640,
-                  480,
-                  rotationMatrix,
-                  translationVector,
-                  rectifiedRotationFirst,
-                  rectifiedRotationSecond,
-                  projectionFirst,
-                  projectionSecond,
-                  reprojectionMatrix);
+    StereoRectify(primaryIntrinsics, noDistortion, secondaryIntrinsics, noDistortion, 640, 480, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
     ExpectMatrixNear(rectifiedRotationFirst, Identity(), kTol);
     ExpectMatrixNear(rectifiedRotationSecond, Identity(), kTol);
@@ -303,22 +284,10 @@ TEST(GeometryTest, StereoRectifyHorizontalBaseline)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(K1,
-                  D1,
-                  K2,
-                  D2,
-                  800,
-                  600,
-                  rotationMatrix,
-                  translationVector,
-                  rectifiedRotationFirst,
-                  rectifiedRotationSecond,
-                  projectionFirst,
-                  projectionSecond,
-                  reprojectionMatrix);
+    StereoRectify(K1, D1, K2, D2, 800, 600, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
-    ExpectOrthonormal(rectifiedRotationFirst, kOrthonormalTol);
-    ExpectOrthonormal(rectifiedRotationSecond, kOrthonormalTol);
+    ExpectOrthonormal(rectifiedRotationFirst, kTol);
+    ExpectOrthonormal(rectifiedRotationSecond, kTol);
 
     const double offsetX = projectionSecond[0][3];
     const double offsetY = projectionSecond[1][3];
@@ -338,14 +307,14 @@ TEST(GeometryTest, StereoRectifyHorizontalBaseline)
     EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTol);
 
     const double translationOffset = offsetX;
-    ASSERT_GT(std::fabs(translationOffset), kMinTranslationTol);
+    ASSERT_GT(std::fabs(translationOffset), kTol);
     const double baselineComponent = translationOffset / expectedFocal;
     const retinify::Vec3d rectifiedTranslation = retinify::Multiply(rectifiedRotationSecond, translationVector);
-    EXPECT_NEAR(rectifiedTranslation[0], baselineComponent, kRectifyTol);
-    EXPECT_NEAR(rectifiedTranslation[1], 0.0, kRectifyTol);
-    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kRectifyTol);
+    EXPECT_NEAR(rectifiedTranslation[0], baselineComponent, kTol);
+    EXPECT_NEAR(rectifiedTranslation[1], 0.0, kTol);
+    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTol);
 
-    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kRectifyTol);
+    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTol);
 }
 
 TEST(GeometryTest, StereoRectifyVerticalBaseline)
@@ -364,22 +333,10 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(K1,
-                  D1,
-                  K2,
-                  D2,
-                  1024,
-                  768,
-                  rotationMatrix,
-                  translationVector,
-                  rectifiedRotationFirst,
-                  rectifiedRotationSecond,
-                  projectionFirst,
-                  projectionSecond,
-                  reprojectionMatrix);
+    StereoRectify(K1, D1, K2, D2, 1024, 768, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
-    ExpectOrthonormal(rectifiedRotationFirst, kOrthonormalTol);
-    ExpectOrthonormal(rectifiedRotationSecond, kOrthonormalTol);
+    ExpectOrthonormal(rectifiedRotationFirst, kTol);
+    ExpectOrthonormal(rectifiedRotationSecond, kTol);
 
     const double offsetX = projectionSecond[0][3];
     const double offsetY = projectionSecond[1][3];
@@ -399,13 +356,127 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
     EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTol);
 
     const double translationOffset = offsetY;
-    ASSERT_GT(std::fabs(translationOffset), kMinTranslationTol);
+    ASSERT_GT(std::fabs(translationOffset), kTol);
     const double baselineComponent = translationOffset / expectedFocal;
     const retinify::Vec3d rectifiedTranslation = retinify::Multiply(rectifiedRotationSecond, translationVector);
-    EXPECT_NEAR(rectifiedTranslation[1], baselineComponent, kRectifyTol);
-    EXPECT_NEAR(rectifiedTranslation[0], 0.0, kRectifyTol);
-    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kRectifyTol);
+    EXPECT_NEAR(rectifiedTranslation[1], baselineComponent, kTol);
+    EXPECT_NEAR(rectifiedTranslation[0], 0.0, kTol);
+    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTol);
 
-    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kRectifyTol);
+    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTol);
+}
+
+TEST(GeometryTest, InitUndistortRectifyMapIdentity)
+{
+    const Intrinsics intrinsics{1.0, 1.0, 0.0, 0.0, 0.0};
+    const Distortion distortion{};
+    const Mat3x3d rectificationRotation = Identity();
+
+    Mat3x4d projection{};
+    projection[0][0] = 1.0;
+    projection[1][1] = 1.0;
+    projection[2][2] = 1.0;
+
+    constexpr int kWidth = 3;
+    constexpr int kHeight = 2;
+
+    std::vector<float> mapX;
+    std::vector<float> mapY;
+
+    InitUndistortRectifyMap(intrinsics, distortion, rectificationRotation, projection, kWidth, kHeight, mapX, mapY);
+
+    ASSERT_EQ(mapX.size(), static_cast<std::size_t>(kWidth * kHeight));
+    ASSERT_EQ(mapY.size(), static_cast<std::size_t>(kWidth * kHeight));
+
+    for (int v = 0; v < kHeight; ++v)
+    {
+        for (int u = 0; u < kWidth; ++u)
+        {
+            const std::size_t index = static_cast<std::size_t>(v * kWidth + u);
+            EXPECT_NEAR(mapX[index], static_cast<float>(u), kTol);
+            EXPECT_NEAR(mapY[index], static_cast<float>(v), kTol);
+        }
+    }
+}
+
+TEST(GeometryTest, InitUndistortRectifyMapRotatedCamera)
+{
+    const Intrinsics intrinsics{4.0, 5.0, 3.0, 2.0, 0.1};
+    const Distortion distortion{};
+    const Mat3x3d rectificationRotation{{{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}}};
+
+    Mat3x4d projection{};
+    projection[0] = {2.0, 0.0, 1.5, 0.0};
+    projection[1] = {0.0, 2.0, 0.5, 0.0};
+    projection[2] = {0.0, 0.0, 1.0, 0.0};
+
+    constexpr int kWidth = 4;
+    constexpr int kHeight = 3;
+
+    std::vector<float> mapX;
+    std::vector<float> mapY;
+
+    InitUndistortRectifyMap(intrinsics, distortion, rectificationRotation, projection, kWidth, kHeight, mapX, mapY);
+
+    ASSERT_EQ(mapX.size(), static_cast<std::size_t>(kWidth * kHeight));
+    ASSERT_EQ(mapY.size(), static_cast<std::size_t>(kWidth * kHeight));
+
+    for (int v = 0; v < kHeight; ++v)
+    {
+        const double rectifiedY = (static_cast<double>(v) - projection[1][2]) / projection[1][1];
+        for (int u = 0; u < kWidth; ++u)
+        {
+            const std::size_t idx = static_cast<std::size_t>(v) * kWidth + static_cast<std::size_t>(u);
+            const double rectifiedX = (static_cast<double>(u) - projection[0][2]) / projection[0][0];
+
+            const double normalizedX = rectifiedY;
+            const double normalizedY = -rectifiedX;
+
+            const double expectedX = intrinsics.fx * normalizedX + intrinsics.skew * normalizedY + intrinsics.cx;
+            const double expectedY = intrinsics.fy * normalizedY + intrinsics.cy;
+
+            EXPECT_NEAR(mapX[idx], static_cast<float>(expectedX), kTol);
+            EXPECT_NEAR(mapY[idx], static_cast<float>(expectedY), kTol);
+        }
+    }
+}
+
+TEST(GeometryTest, InitUndistortRectifyMapAppliesDistortion)
+{
+    const Intrinsics intrinsics{500.0, 520.0, 320.0, 240.0, 0.0};
+    const Distortion distortion{0.05, -0.01, 0.001, -0.0004, 0.0005, -0.0002, 0.0001, -5e-5};
+    const Mat3x3d rectificationRotation = Identity();
+
+    Mat3x4d projection{};
+    projection[0] = {450.0, 0.0, 300.0, 0.0};
+    projection[1] = {0.0, 460.0, 200.0, 0.0};
+    projection[2] = {0.0, 0.0, 1.0, 0.0};
+
+    constexpr int kWidth = 2;
+    constexpr int kHeight = 2;
+
+    std::vector<float> mapX;
+    std::vector<float> mapY;
+
+    InitUndistortRectifyMap(intrinsics, distortion, rectificationRotation, projection, kWidth, kHeight, mapX, mapY);
+
+    ASSERT_EQ(mapX.size(), static_cast<std::size_t>(kWidth * kHeight));
+    ASSERT_EQ(mapY.size(), static_cast<std::size_t>(kWidth * kHeight));
+
+    for (int v = 0; v < kHeight; ++v)
+    {
+        for (int u = 0; u < kWidth; ++u)
+        {
+            const std::size_t idx = static_cast<std::size_t>(v) * kWidth + static_cast<std::size_t>(u);
+            const double rectifiedX = (static_cast<double>(u) - projection[0][2]) / projection[0][0];
+            const double rectifiedY = (static_cast<double>(v) - projection[1][2]) / projection[1][1];
+
+            const Point2d idealPixel{rectifiedX, rectifiedY};
+            const Point2d distortedPixel = DistortPoint(intrinsics, distortion, idealPixel);
+
+            EXPECT_NEAR(mapX[idx], static_cast<float>(distortedPixel[0]), kTol);
+            EXPECT_NEAR(mapY[idx], static_cast<float>(distortedPixel[1]), kTol);
+        }
+    }
 }
 } // namespace retinify


### PR DESCRIPTION
Introduce a new function to initialize undistort and rectify maps for image remapping, along with corresponding tests to ensure functionality.