### PR TITLE
Update installation instructions for CUDA Toolkit versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,27 +75,32 @@ pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0],   //
   Detailed class and function-level documentation for developers.
 
 ## Supported Backends
-| 🎯 Target                            | Status                                                                 |
-| ----------------------------------- | ---------------------------------------------------------------------- |
-| ![target-tensorrt10-cuda12-badge]   | [![build-tensorrt10-cuda12-badge]][build-tensorrt10-cuda12-status]     |
-| ![target-tensorrt10-cuda13-badge]   | [![build-tensorrt10-cuda13-badge]][build-tensorrt10-cuda13-status]     |
-| ![target-tensorrt10-jetpack6-badge] | [![build-tensorrt10-jetpack6-badge]][build-tensorrt10-jetpack6-status] |
-| ![target-hailort-badge]             | Coming soon                                                            |
-| ![target-openvino-badge]            | Coming soon                                                            |
+| 🎯 Target             | ⚙️ Env           | 📦 Status                                                               |
+| -------------------- | --------------- | ---------------------------------------------------------------------- |
+| ![target-tensorrt10] | ![env-cuda12]   | [![build-tensorrt10-cuda12-badge]][build-tensorrt10-cuda12-status]     |
+| ![target-tensorrt10] | ![env-cuda13]   | [![build-tensorrt10-cuda13-badge]][build-tensorrt10-cuda13-status]     |
+| ![target-tensorrt10] | ![env-jetpack6] | [![build-tensorrt10-jetpack6-badge]][build-tensorrt10-jetpack6-status] |
+| ![target-hailort]    | ![env-na]       | ![status-planned]                                                      |
+| ![target-openvino]   | ![env-na]       | ![status-planned]                                                      |
 
-[target-tensorrt10-cuda12-badge]: https://img.shields.io/badge/TensorRT(CUDA12.X)-gray?style=flat-square
-[target-tensorrt10-cuda13-badge]: https://img.shields.io/badge/TensorRT(CUDA13.X)-gray?style=flat-square
-[target-tensorrt10-jetpack6-badge]: https://img.shields.io/badge/TensorRT(JetPack6)-gray?style=flat-square
-[target-hailort-badge]: https://img.shields.io/badge/HailoRT-gray?style=flat-square
-[target-openvino-badge]: https://img.shields.io/badge/OpenVINO-gray?style=flat-square
+[target-tensorrt10]: https://img.shields.io/badge/-TensorRT%2010-76B900?style=flat-square&logo=nvidia&logoColor=white
+[target-hailort]:    https://img.shields.io/badge/-HailoRT-gray?style=flat-square
+[target-openvino]:   https://img.shields.io/badge/-OpenVINO-gray?style=flat-square
 
-[build-tensorrt10-cuda12-badge]: https://img.shields.io/github/actions/workflow/status/retinify/retinify/build-tensorrt10-cuda12.yml?style=flat-square&label=build
-[build-tensorrt10-cuda13-badge]: https://img.shields.io/github/actions/workflow/status/retinify/retinify/build-tensorrt10-cuda13.yml?style=flat-square&label=build
+[env-cuda12]:   https://img.shields.io/badge/-CUDA%2012.x-76B900?style=flat-square&logo=nvidia&logoColor=white
+[env-cuda13]:   https://img.shields.io/badge/-CUDA%2013.x-76B900?style=flat-square&logo=nvidia&logoColor=white
+[env-jetpack6]: https://img.shields.io/badge/-JETPACK%206-76B900?style=flat-square&logo=nvidia&logoColor=white
+[env-na]:       https://img.shields.io/badge/-TBD-lightgray?style=flat-square
+
+[build-tensorrt10-cuda12-badge]:  https://img.shields.io/github/actions/workflow/status/retinify/retinify/build-tensorrt10-cuda12.yml?style=flat-square&label=build
+[build-tensorrt10-cuda13-badge]:  https://img.shields.io/github/actions/workflow/status/retinify/retinify/build-tensorrt10-cuda13.yml?style=flat-square&label=build
 [build-tensorrt10-jetpack6-badge]: https://img.shields.io/github/actions/workflow/status/retinify/retinify/build-tensorrt10-jetpack6.yml?style=flat-square&label=build
 
-[build-tensorrt10-cuda12-status]: https://github.com/retinify/retinify/actions/workflows/build-tensorrt10-cuda12.yml?query=branch%3Amain
-[build-tensorrt10-cuda13-status]: https://github.com/retinify/retinify/actions/workflows/build-tensorrt10-cuda13.yml?query=branch%3Amain
+[build-tensorrt10-cuda12-status]:   https://github.com/retinify/retinify/actions/workflows/build-tensorrt10-cuda12.yml?query=branch%3Amain
+[build-tensorrt10-cuda13-status]:   https://github.com/retinify/retinify/actions/workflows/build-tensorrt10-cuda13.yml?query=branch%3Amain
 [build-tensorrt10-jetpack6-status]: https://github.com/retinify/retinify/actions/workflows/build-tensorrt10-jetpack6.yml?query=branch%3Amain
+
+[status-planned]: https://img.shields.io/badge/-Planned-lightgray?style=flat-square
 
 ## Pipeline Latencies
 Latency includes the time for image upload, inference, and disparity download, reported as the median over 10,000 iterations (measured with `retinify::Pipeline`).  

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -1,6 +1,6 @@
 @page installation Installation
 
-retinify supports Linux (Ubuntu) and can be easily installed using the provided `build.sh` script.  
+Retinify supports Linux (Ubuntu) and can be easily installed using the provided `build.sh` script.  
 This script generates a Debian package, enabling clean installation, easy updating, and simple removal using standard package management tools.  
 
 ## Dependencies
@@ -9,7 +9,7 @@ Build Toolchain
 - [CMake](https://cmake.org/download/): 3.14 or later
   
 AI Runtime
-- [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive): 12.x
+- [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive): 12.x, 13.x
 - [cuDNN](https://developer.nvidia.com/cudnn-archive): 9.x
 - [TensorRT](https://developer.nvidia.com/tensorrt): 10.x
 


### PR DESCRIPTION
Update the documentation to reflect support for both CUDA Toolkit 12.x and 13.x in the installation instructions. Adjust the status badges for better clarity on supported targets and environments.