### PR TITLE
Refactor stereo rectification and undistortion functions for clarity

### DIFF
--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -195,53 +195,53 @@ RETINIFY_API auto UndistortPoint(const Intrinsics &intrinsics, const Distortion 
 
 /// @brief
 /// Perform stereo rectification for a pair of cameras.
-/// @param K1
+/// @param intrinsics1
 /// First camera intrinsics.
-/// @param D1
+/// @param distortion1
 /// First camera distortion.
-/// @param K2
+/// @param intrinsics2
 /// Second camera intrinsics.
-/// @param D2
+/// @param distortion2
 /// Second camera distortion.
-/// @param width
+/// @param imageWidth
 /// Image width in pixels.
-/// @param height
+/// @param imageHeight
 /// Image height in pixels.
-/// @param R
+/// @param rotation
 /// Rotation from the first to the second camera.
-/// @param T
+/// @param translation
 /// Translation from the first to the second camera.
-/// @param R1
+/// @param rotation1
 /// Output rectification rotation for the first camera.
-/// @param R2
+/// @param rotation2
 /// Output rectification rotation for the second camera.
-/// @param P1
+/// @param projectionMatrix1
 /// Output projection matrix for the first camera.
-/// @param P2
+/// @param projectionMatrix2
 /// Output projection matrix for the second camera.
-/// @param Q
+/// @param mappingMatrix
 /// Output mapping matrix.
-RETINIFY_API auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
-                                const Intrinsics &K2, const Distortion &D2, //
-                                int width, int height,                      //
-                                const Mat3x3d &R, const Vec3d &T,           //
-                                Mat3x3d &R1, Mat3x3d &R2,                   //
-                                Mat3x4d &P1, Mat3x4d &P2,                   //
-                                Mat4x4d &Q) noexcept -> void;
+RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
+                                const Intrinsics &intrinsics2, const Distortion &distortion2, //
+                                int imageWidth, int imageHeight,                              //
+                                const Mat3x3d &rotation, const Vec3d &translation,            //
+                                Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
+                                Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
+                                Mat4x4d &mappingMatrix) noexcept -> void;
 
 /// @brief
 /// Initialize undistort and rectify maps for image remapping.
-/// @param K
+/// @param intrinsics
 /// Camera intrinsics
-/// @param D
+/// @param distortion
 /// Distortion parameters
-/// @param R
+/// @param rotation
 /// Rectification rotation
-/// @param P
+/// @param projectionMatrix
 /// Projection matrix
-/// @param width
+/// @param imageWidth
 /// Image width
-/// @param height
+/// @param imageHeight
 /// Image height
 /// @param mapx
 /// Output map for x-coordinates
@@ -252,10 +252,9 @@ RETINIFY_API auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
 /// @param mapyStride
 /// Stride (in bytes) of a row in mapy
 /// @return
-RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
-                                          const Mat3x3d &R,                         //
-                                          const Mat3x4d &P,                         //
-                                          int width, int height,                    //
-                                          float *mapx, std::size_t mapxStride,      //
+RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
+                                          const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
+                                          int imageWidth, int imageHeight,                            //
+                                          float *mapx, std::size_t mapxStride,                        //
                                           float *mapy, std::size_t mapyStride) noexcept -> void;
 } // namespace retinify

--- a/retinify/src/geometry.cpp
+++ b/retinify/src/geometry.cpp
@@ -357,64 +357,63 @@ static auto BuildProjectionMatrix(double focal, const Point2d &principal) noexce
 }
 } // namespace
 
-auto StereoRectify(const Intrinsics &K1, const Distortion &D1, //
-                   const Intrinsics &K2, const Distortion &D2, //
-                   int width, int height,                      //
-                   const Mat3x3d &R, const Vec3d &T,           //
-                   Mat3x3d &R1, Mat3x3d &R2,                   //
-                   Mat3x4d &P1, Mat3x4d &P2,                   //
-                   Mat4x4d &Q) noexcept -> void
+auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
+                   const Intrinsics &intrinsics2, const Distortion &distortion2, //
+                   int imageWidth, int imageHeight,                              //
+                   const Mat3x3d &rotation, const Vec3d &translation,            //
+                   Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
+                   Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
+                   Mat4x4d &mappingMatrix) noexcept -> void
 {
-    // Stereo rectification: R1 = R_align R_rect^T, R2 = R_align R_rect,
+    // Stereo rectification: rotation1 = R_align R_rect^T, rotation2 = R_align R_rect,
     // share focal f = 0.5 * ((fx1+fx2) if axis=y else (fy1+fy2)), and set disparity scale via baseline
-    const Mat3x3d rectifyingRotation = ComputeRectifyingRotation(R);
-    const Vec3d rotatedTranslation = Multiply(rectifyingRotation, T);
+    const Mat3x3d rectifyingRotation = ComputeRectifyingRotation(rotation);
+    const Vec3d rotatedTranslation = Multiply(rectifyingRotation, translation);
     const int axisIdx = DetermineDominantAxis(rotatedTranslation);
     const Mat3x3d baselineAlignment = ComputeBaselineAlignment(rotatedTranslation, axisIdx);
 
     const Mat3x3d rotationTranspose = Transpose(rectifyingRotation);
-    R1 = Multiply(baselineAlignment, rotationTranspose);
-    R2 = Multiply(baselineAlignment, rectifyingRotation);
+    rotation1 = Multiply(baselineAlignment, rotationTranspose);
+    rotation2 = Multiply(baselineAlignment, rectifyingRotation);
 
-    const Vec3d rectifiedTranslation = Multiply(R2, T);
+    const Vec3d rectifiedTranslation = Multiply(rotation2, translation);
     const double newFocalScale = 0.5;
-    const double newFocalLength = (axisIdx == 0) ? (K1.fy + K2.fy) * newFocalScale : (K1.fx + K2.fx) * newFocalScale;
+    const double newFocalLength = (axisIdx == 0) ? (intrinsics1.fy + intrinsics2.fy) * newFocalScale : (intrinsics1.fx + intrinsics2.fx) * newFocalScale;
 
-    const Point2d principal1 = ComputePrincipalPoint(K1, D1, R1, newFocalLength, static_cast<double>(width), static_cast<double>(height));
-    const Point2d principal2 = ComputePrincipalPoint(K2, D2, R2, newFocalLength, static_cast<double>(width), static_cast<double>(height));
+    const Point2d principal1 = ComputePrincipalPoint(intrinsics1, distortion1, rotation1, newFocalLength, static_cast<double>(imageWidth), static_cast<double>(imageHeight));
+    const Point2d principal2 = ComputePrincipalPoint(intrinsics2, distortion2, rotation2, newFocalLength, static_cast<double>(imageWidth), static_cast<double>(imageHeight));
     const double cxAvg = 0.5 * (principal1[0] + principal2[0]);
     const double cyAvg = 0.5 * (principal1[1] + principal2[1]);
     const Point2d principalAvg{cxAvg, cyAvg};
 
-    P1 = BuildProjectionMatrix(newFocalLength, principalAvg);
-    P2 = BuildProjectionMatrix(newFocalLength, principalAvg);
+    projectionMatrix1 = BuildProjectionMatrix(newFocalLength, principalAvg);
+    projectionMatrix2 = BuildProjectionMatrix(newFocalLength, principalAvg);
 
     const double baselineComponent = (axisIdx == 0) ? rectifiedTranslation[0] : rectifiedTranslation[1];
     const double translationOffset = baselineComponent * newFocalLength;
     if (axisIdx == 0)
     {
-        P2[0][3] = translationOffset;
+        projectionMatrix2[0][3] = translationOffset;
     }
     else
     {
-        P2[1][3] = translationOffset;
+        projectionMatrix2[1][3] = translationOffset;
     }
 
-    Q = Mat4x4d{};
-    Q[0][0] = 1.0;
-    Q[1][1] = 1.0;
-    Q[0][3] = -principalAvg[0];
-    Q[1][3] = -principalAvg[1];
-    Q[2][3] = newFocalLength;
-    Q[3][2] = (std::fabs(baselineComponent) > kEpsilon) ? (-1.0 / baselineComponent) : 0.0;
-    Q[3][3] = 0.0;
+    mappingMatrix = Mat4x4d{};
+    mappingMatrix[0][0] = 1.0;
+    mappingMatrix[1][1] = 1.0;
+    mappingMatrix[0][3] = -principalAvg[0];
+    mappingMatrix[1][3] = -principalAvg[1];
+    mappingMatrix[2][3] = newFocalLength;
+    mappingMatrix[3][2] = (std::fabs(baselineComponent) > kEpsilon) ? (-1.0 / baselineComponent) : 0.0;
+    mappingMatrix[3][3] = 0.0;
 }
 
-auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
-                             const Mat3x3d &R,                         //
-                             const Mat3x4d &P,                         //
-                             int width, int height,                    //
-                             float *mapx, std::size_t mapxStride,      //
+auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
+                             const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
+                             int imageWidth, int imageHeight,                            //
+                             float *mapx, std::size_t mapxStride,                        //
                              float *mapy, std::size_t mapyStride) noexcept -> void
 {
     if (mapx == nullptr || mapy == nullptr)
@@ -422,9 +421,9 @@ auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
         return;
     }
 
-    const Mat3x3d rotationInverse = Transpose(R);
-    const auto &projRow0 = P[0];
-    const auto &projRow1 = P[1];
+    const Mat3x3d rotationInverse = Transpose(rotation);
+    const auto &projRow0 = projectionMatrix[0];
+    const auto &projRow1 = projectionMatrix[1];
     const double invRectifiedFocalX = Reciprocal(projRow0[0], 0.0);
     const double invRectifiedFocalY = Reciprocal(projRow1[1], 0.0);
     const double rectifiedPrincipalX = projRow0[2];
@@ -433,14 +432,14 @@ auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
     auto *mapxBytes = static_cast<unsigned char *>(static_cast<void *>(mapx));
     auto *mapyBytes = static_cast<unsigned char *>(static_cast<void *>(mapy));
 
-    for (int v = 0; v < height; ++v)
+    for (int v = 0; v < imageHeight; ++v)
     {
         const std::size_t offsetX = static_cast<std::size_t>(v) * mapxStride;
         const std::size_t offsetY = static_cast<std::size_t>(v) * mapyStride;
         auto *mapxRow = static_cast<float *>(static_cast<void *>(mapxBytes + offsetX));
         auto *mapyRow = static_cast<float *>(static_cast<void *>(mapyBytes + offsetY));
         const double rectifiedY = (static_cast<double>(v) - rectifiedPrincipalY) * invRectifiedFocalY;
-        for (int u = 0; u < width; ++u)
+        for (int u = 0; u < imageWidth; ++u)
         {
             const double rectifiedX = (static_cast<double>(u) - rectifiedPrincipalX) * invRectifiedFocalX;
             const Vec3d rectifiedPoint{rectifiedX, rectifiedY, 1.0};
@@ -453,19 +452,19 @@ auto InitUndistortRectifyMap(const Intrinsics &K, const Distortion &D, //
             const double radiusSquared = Square(normalizedX) + Square(normalizedY);
             const double radiusFourth = radiusSquared * radiusSquared;
             const double radiusSixth = radiusFourth * radiusSquared;
-            const double radialNumerator = 1.0 + D.k1 * radiusSquared + D.k2 * radiusFourth + D.k3 * radiusSixth;
-            const double radialDenominator = 1.0 + D.k4 * radiusSquared + D.k5 * radiusFourth + D.k6 * radiusSixth;
+            const double radialNumerator = 1.0 + distortion.k1 * radiusSquared + distortion.k2 * radiusFourth + distortion.k3 * radiusSixth;
+            const double radialDenominator = 1.0 + distortion.k4 * radiusSquared + distortion.k5 * radiusFourth + distortion.k6 * radiusSixth;
             const double radialScale = (std::fabs(radialDenominator) > kEpsilon) ? (radialNumerator / radialDenominator) : 1.0;
 
             const double twoNormalizedXY = 2.0 * normalizedX * normalizedY;
             const double normalizedXSquared = Square(normalizedX);
             const double normalizedYSquared = Square(normalizedY);
 
-            const double distortedNormalizedX = normalizedX * radialScale + D.p1 * twoNormalizedXY + D.p2 * (radiusSquared + 2.0 * normalizedXSquared);
-            const double distortedNormalizedY = normalizedY * radialScale + D.p1 * (radiusSquared + 2.0 * normalizedYSquared) + D.p2 * twoNormalizedXY;
+            const double distortedNormalizedX = normalizedX * radialScale + distortion.p1 * twoNormalizedXY + distortion.p2 * (radiusSquared + 2.0 * normalizedXSquared);
+            const double distortedNormalizedY = normalizedY * radialScale + distortion.p1 * (radiusSquared + 2.0 * normalizedYSquared) + distortion.p2 * twoNormalizedXY;
 
-            const double uDistorted = K.fx * distortedNormalizedX + K.skew * distortedNormalizedY + K.cx;
-            const double vDistorted = K.fy * distortedNormalizedY + K.cy;
+            const double uDistorted = intrinsics.fx * distortedNormalizedX + intrinsics.skew * distortedNormalizedY + intrinsics.cx;
+            const double vDistorted = intrinsics.fy * distortedNormalizedY + intrinsics.cy;
             mapxRow[u] = static_cast<float>(uDistorted);
             mapyRow[u] = static_cast<float>(vDistorted);
         }

--- a/retinify/tests/geometry_test.cpp
+++ b/retinify/tests/geometry_test.cpp
@@ -5,14 +5,20 @@
 
 #include "mat.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 
 #include <gtest/gtest.h>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/core.hpp>
 
 namespace retinify
 {
-constexpr double kTol = 1e-12;
+namespace
+{
+constexpr double kTolLoose = 1e-5;
+constexpr double kTolStrict = 1e-12;
 
 void ExpectMatrixNear(const retinify::Mat3x3d &lhs, const retinify::Mat3x3d &rhs, double tol)
 {
@@ -62,6 +68,7 @@ void ExpectMatrix44Near(const retinify::Mat4x4d &lhs, const retinify::Mat4x4d &r
         }
     }
 }
+} // namespace
 
 TEST(GeometryTest, MultiplyMatrixVector)
 {
@@ -70,7 +77,7 @@ TEST(GeometryTest, MultiplyMatrixVector)
 
     const retinify::Vec3d result = retinify::Multiply(mat, vec);
 
-    ExpectVectorNear(result, {1.5, 3.0, 5.0}, kTol);
+    ExpectVectorNear(result, {1.5, 3.0, 5.0}, kTolStrict);
 }
 
 TEST(GeometryTest, MultiplyWithIdentityPreservesMatrix)
@@ -78,26 +85,26 @@ TEST(GeometryTest, MultiplyWithIdentityPreservesMatrix)
     const retinify::Mat3x3d matrixA{{{1.0, 2.0, -1.0}, {0.5, -0.25, 3.0}, {4.0, 1.0, 0.0}}};
     const retinify::Mat3x3d identityMatrix = Identity();
 
-    ExpectMatrixNear(retinify::Multiply(identityMatrix, matrixA), matrixA, kTol);
-    ExpectMatrixNear(retinify::Multiply(matrixA, identityMatrix), matrixA, kTol);
+    ExpectMatrixNear(retinify::Multiply(identityMatrix, matrixA), matrixA, kTolStrict);
+    ExpectMatrixNear(retinify::Multiply(matrixA, identityMatrix), matrixA, kTolStrict);
 }
 
 TEST(GeometryTest, TransposeIsInvolution)
 {
     const retinify::Mat3x3d mat{{{0.0, 1.0, 2.0}, {3.0, 4.0, 5.0}, {6.0, 7.0, 8.0}}};
-    ExpectMatrixNear(retinify::Transpose(retinify::Transpose(mat)), mat, kTol);
+    ExpectMatrixNear(retinify::Transpose(retinify::Transpose(mat)), mat, kTolStrict);
 }
 
 TEST(GeometryTest, LengthAndNormalize)
 {
     const retinify::Vec3d vec{3.0, 4.0, 12.0};
-    EXPECT_NEAR(retinify::Length(vec), std::sqrt(169.0), kTol);
+    EXPECT_NEAR(retinify::Length(vec), std::sqrt(169.0), kTolStrict);
 
     const retinify::Vec3d unit = retinify::Normalize(vec);
-    EXPECT_NEAR(retinify::Length(unit), 1.0, kTol);
+    EXPECT_NEAR(retinify::Length(unit), 1.0, kTolStrict);
 
     const retinify::Vec3d zero{0.0, 0.0, 0.0};
-    ExpectVectorNear(retinify::Normalize(zero), zero, kTol);
+    ExpectVectorNear(retinify::Normalize(zero), zero, kTolStrict);
 }
 
 TEST(GeometryTest, CrossProductOrthogonality)
@@ -106,23 +113,23 @@ TEST(GeometryTest, CrossProductOrthogonality)
     const retinify::Vec3d vectorV{-4.0, 5.0, -6.0};
     const retinify::Vec3d cross = retinify::Cross(vectorU, vectorV);
 
-    EXPECT_NEAR(cross[0] * vectorU[0] + cross[1] * vectorU[1] + cross[2] * vectorU[2], 0.0, kTol);
-    EXPECT_NEAR(cross[0] * vectorV[0] + cross[1] * vectorV[1] + cross[2] * vectorV[2], 0.0, kTol);
+    EXPECT_NEAR(cross[0] * vectorU[0] + cross[1] * vectorU[1] + cross[2] * vectorU[2], 0.0, kTolStrict);
+    EXPECT_NEAR(cross[0] * vectorV[0] + cross[1] * vectorV[1] + cross[2] * vectorV[2], 0.0, kTolStrict);
 
     const double lenUSq = vectorU[0] * vectorU[0] + vectorU[1] * vectorU[1] + vectorU[2] * vectorU[2];
     const double lenVSq = vectorV[0] * vectorV[0] + vectorV[1] * vectorV[1] + vectorV[2] * vectorV[2];
     const double dotUV = vectorU[0] * vectorV[0] + vectorU[1] * vectorV[1] + vectorU[2] * vectorV[2];
     const double expectedSq = lenUSq * lenVSq - dotUV * dotUV;
     const double crossSq = cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2];
-    EXPECT_NEAR(crossSq, expectedSq, kTol);
+    EXPECT_NEAR(crossSq, expectedSq, kTolStrict);
 
     const retinify::Vec3d reversed = retinify::Cross(vectorV, vectorU);
-    ExpectVectorNear(reversed, {-cross[0], -cross[1], -cross[2]}, kTol);
+    ExpectVectorNear(reversed, {-cross[0], -cross[1], -cross[2]}, kTolStrict);
 }
 
 TEST(GeometryTest, ExpReturnsIdentityForZeroRotation)
 {
-    ExpectMatrixNear(retinify::Exp({0.0, 0.0, 0.0}), Identity(), kTol);
+    ExpectMatrixNear(retinify::Exp({0.0, 0.0, 0.0}), Identity(), kTolStrict);
 }
 
 TEST(GeometryTest, ExpMatchesCardinalAxisRotations)
@@ -132,32 +139,32 @@ TEST(GeometryTest, ExpMatchesCardinalAxisRotations)
     const double sinTheta = std::sin(theta);
 
     const retinify::Mat3x3d Rx = retinify::Exp({theta, 0.0, 0.0});
-    ExpectMatrixNear(Rx, {{{1.0, 0.0, 0.0}, {0.0, cosTheta, -sinTheta}, {0.0, sinTheta, cosTheta}}}, kTol);
+    ExpectMatrixNear(Rx, {{{1.0, 0.0, 0.0}, {0.0, cosTheta, -sinTheta}, {0.0, sinTheta, cosTheta}}}, kTolStrict);
 
     const retinify::Mat3x3d Ry = retinify::Exp({0.0, theta, 0.0});
-    ExpectMatrixNear(Ry, {{{cosTheta, 0.0, sinTheta}, {0.0, 1.0, 0.0}, {-sinTheta, 0.0, cosTheta}}}, kTol);
+    ExpectMatrixNear(Ry, {{{cosTheta, 0.0, sinTheta}, {0.0, 1.0, 0.0}, {-sinTheta, 0.0, cosTheta}}}, kTolStrict);
 
     const retinify::Mat3x3d Rz = retinify::Exp({0.0, 0.0, theta});
-    ExpectMatrixNear(Rz, {{{cosTheta, -sinTheta, 0.0}, {sinTheta, cosTheta, 0.0}, {0.0, 0.0, 1.0}}}, kTol);
+    ExpectMatrixNear(Rz, {{{cosTheta, -sinTheta, 0.0}, {sinTheta, cosTheta, 0.0}, {0.0, 0.0, 1.0}}}, kTolStrict);
 }
 
 TEST(GeometryTest, ExpProducesProperRotation)
 {
     const retinify::Vec3d omega{0.7, -0.2, 0.4};
     const retinify::Mat3x3d rotationMatrix = retinify::Exp(omega);
-    ExpectOrthonormal(rotationMatrix, kTol);
+    ExpectOrthonormal(rotationMatrix, kTolStrict);
 }
 
 TEST(GeometryTest, LogOfIdentityIsZero)
 {
-    ExpectVectorNear(retinify::Log(Identity()), {0.0, 0.0, 0.0}, kTol);
+    ExpectVectorNear(retinify::Log(Identity()), {0.0, 0.0, 0.0}, kTolStrict);
 }
 
 TEST(GeometryTest, LogRecoversRotationVector)
 {
     const retinify::Vec3d omega{1e-4, -2e-4, 1.5e-4};
     const retinify::Vec3d recovered = retinify::Log(retinify::Exp(omega));
-    ExpectVectorNear(recovered, omega, kTol);
+    ExpectVectorNear(recovered, omega, kTolStrict);
 }
 
 TEST(GeometryTest, ExpLogRoundTrip)
@@ -165,7 +172,7 @@ TEST(GeometryTest, ExpLogRoundTrip)
     const retinify::Mat3x3d rotationMatrix = retinify::Exp({-0.8, 0.3, 0.1});
     const retinify::Vec3d logR = retinify::Log(rotationMatrix);
     const retinify::Mat3x3d reconstructed = retinify::Exp(logR);
-    ExpectMatrixNear(reconstructed, rotationMatrix, kTol);
+    ExpectMatrixNear(reconstructed, rotationMatrix, kTolStrict);
 }
 
 TEST(GeometryTest, LogHandlesPiRotation)
@@ -174,9 +181,9 @@ TEST(GeometryTest, LogHandlesPiRotation)
     const retinify::Mat3x3d rotationMatrix{{{1.0, 0.0, 0.0}, {0.0, -1.0, 0.0}, {0.0, 0.0, -1.0}}};
     const retinify::Vec3d omega = retinify::Log(rotationMatrix);
 
-    EXPECT_NEAR(std::fabs(omega[0]), theta, kTol);
-    EXPECT_NEAR(omega[1], 0.0, kTol);
-    EXPECT_NEAR(omega[2], 0.0, kTol);
+    EXPECT_NEAR(std::fabs(omega[0]), theta, kTolStrict);
+    EXPECT_NEAR(omega[1], 0.0, kTolStrict);
+    EXPECT_NEAR(omega[2], 0.0, kTolStrict);
 }
 
 auto DistortPoint(const Intrinsics &intrinsics, const Distortion &distortion, const Point2d &pixel) noexcept -> Point2d
@@ -189,7 +196,7 @@ auto DistortPoint(const Intrinsics &intrinsics, const Distortion &distortion, co
 
     const double radialNumerator = 1.0 + distortion.k1 * r2 + distortion.k2 * r4 + distortion.k3 * r6;
     const double radialDenominator = 1.0 + distortion.k4 * r2 + distortion.k5 * r4 + distortion.k6 * r6;
-    const double radial = (std::fabs(radialDenominator) > kTol) ? (radialNumerator / radialDenominator) : 1.0;
+    const double radial = (std::fabs(radialDenominator) > kTolStrict) ? (radialNumerator / radialDenominator) : 1.0;
 
     const double deltaX = 2.0 * distortion.p1 * pixelX * pixelY + distortion.p2 * (r2 + 2.0 * pixelX * pixelX);
     const double deltaY = distortion.p1 * (r2 + 2.0 * pixelY * pixelY) + 2.0 * distortion.p2 * pixelX * pixelY;
@@ -210,8 +217,8 @@ TEST(GeometryTest, UndistortPointWithFiveCoefficients)
 
     const retinify::Point2d undistortedPixel = retinify::UndistortPoint(intrinsics, distortion, distortedPixel);
 
-    EXPECT_NEAR(undistortedPixel[0], idealPixel[0], kTol);
-    EXPECT_NEAR(undistortedPixel[1], idealPixel[1], kTol);
+    EXPECT_NEAR(undistortedPixel[0], idealPixel[0], kTolStrict);
+    EXPECT_NEAR(undistortedPixel[1], idealPixel[1], kTolStrict);
 }
 
 TEST(GeometryTest, UndistortPointWithEightCoefficients)
@@ -224,8 +231,8 @@ TEST(GeometryTest, UndistortPointWithEightCoefficients)
 
     const retinify::Point2d undistortedPixel = retinify::UndistortPoint(intrinsics, distortion, distortedPixel);
 
-    EXPECT_NEAR(undistortedPixel[0], idealPixel[0], kTol);
-    EXPECT_NEAR(undistortedPixel[1], idealPixel[1], kTol);
+    EXPECT_NEAR(undistortedPixel[0], idealPixel[0], kTolStrict);
+    EXPECT_NEAR(undistortedPixel[1], idealPixel[1], kTolStrict);
 }
 
 TEST(GeometryTest, StereoRectifyIdealRig)
@@ -245,8 +252,8 @@ TEST(GeometryTest, StereoRectifyIdealRig)
 
     StereoRectify(primaryIntrinsics, noDistortion, secondaryIntrinsics, noDistortion, 640, 480, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
-    ExpectMatrixNear(rectifiedRotationFirst, Identity(), kTol);
-    ExpectMatrixNear(rectifiedRotationSecond, Identity(), kTol);
+    ExpectMatrixNear(rectifiedRotationFirst, Identity(), kTolStrict);
+    ExpectMatrixNear(rectifiedRotationSecond, Identity(), kTolStrict);
 
     const double expectedFocal = 500.0;
     const double expectedCx = 320.0;
@@ -255,11 +262,11 @@ TEST(GeometryTest, StereoRectifyIdealRig)
     expectedP1[0] = {expectedFocal, 0.0, expectedCx, 0.0};
     expectedP1[1] = {0.0, expectedFocal, expectedCy, 0.0};
     expectedP1[2] = {0.0, 0.0, 1.0, 0.0};
-    ExpectMatrix34Near(projectionFirst, expectedP1, kTol);
+    ExpectMatrix34Near(projectionFirst, expectedP1, kTolStrict);
 
     retinify::Mat3x4d expectedP2 = expectedP1;
     expectedP2[0][3] = expectedFocal * translationVector[0];
-    ExpectMatrix34Near(projectionSecond, expectedP2, kTol);
+    ExpectMatrix34Near(projectionSecond, expectedP2, kTolStrict);
 
     retinify::Mat4x4d expectedQ{};
     expectedQ[0][0] = 1.0;
@@ -268,7 +275,7 @@ TEST(GeometryTest, StereoRectifyIdealRig)
     expectedQ[1][3] = -expectedCy;
     expectedQ[2][3] = expectedFocal;
     expectedQ[3][2] = -1.0 / translationVector[0];
-    ExpectMatrix44Near(reprojectionMatrix, expectedQ, kTol);
+    ExpectMatrix44Near(reprojectionMatrix, expectedQ, kTolStrict);
 }
 
 TEST(GeometryTest, StereoRectifyHorizontalBaseline)
@@ -289,35 +296,35 @@ TEST(GeometryTest, StereoRectifyHorizontalBaseline)
 
     StereoRectify(K1, D1, K2, D2, 800, 600, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
-    ExpectOrthonormal(rectifiedRotationFirst, kTol);
-    ExpectOrthonormal(rectifiedRotationSecond, kTol);
+    ExpectOrthonormal(rectifiedRotationFirst, kTolStrict);
+    ExpectOrthonormal(rectifiedRotationSecond, kTolStrict);
 
     const double offsetX = projectionSecond[0][3];
     const double offsetY = projectionSecond[1][3];
     EXPECT_GT(std::fabs(offsetX), std::fabs(offsetY));
-    EXPECT_NEAR(offsetY, 0.0, kTol);
+    EXPECT_NEAR(offsetY, 0.0, kTolStrict);
     const double expectedFocal = (K1.fy + K2.fy) * 0.5;
 
-    EXPECT_NEAR(projectionFirst[0][0], expectedFocal, kTol);
-    EXPECT_NEAR(projectionFirst[1][1], expectedFocal, kTol);
-    EXPECT_NEAR(projectionSecond[0][0], expectedFocal, kTol);
-    EXPECT_NEAR(projectionSecond[1][1], expectedFocal, kTol);
+    EXPECT_NEAR(projectionFirst[0][0], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][1], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionSecond[0][0], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionSecond[1][1], expectedFocal, kTolStrict);
 
-    EXPECT_NEAR(projectionFirst[0][2], projectionSecond[0][2], kTol);
-    EXPECT_NEAR(projectionFirst[1][2], projectionSecond[1][2], kTol);
-    EXPECT_NEAR(projectionFirst[0][2], -reprojectionMatrix[0][3], kTol);
-    EXPECT_NEAR(projectionFirst[1][2], -reprojectionMatrix[1][3], kTol);
-    EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTol);
+    EXPECT_NEAR(projectionFirst[0][2], projectionSecond[0][2], kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][2], projectionSecond[1][2], kTolStrict);
+    EXPECT_NEAR(projectionFirst[0][2], -reprojectionMatrix[0][3], kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][2], -reprojectionMatrix[1][3], kTolStrict);
+    EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTolStrict);
 
     const double translationOffset = offsetX;
-    ASSERT_GT(std::fabs(translationOffset), kTol);
+    ASSERT_GT(std::fabs(translationOffset), kTolStrict);
     const double baselineComponent = translationOffset / expectedFocal;
     const retinify::Vec3d rectifiedTranslation = retinify::Multiply(rectifiedRotationSecond, translationVector);
-    EXPECT_NEAR(rectifiedTranslation[0], baselineComponent, kTol);
-    EXPECT_NEAR(rectifiedTranslation[1], 0.0, kTol);
-    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTol);
+    EXPECT_NEAR(rectifiedTranslation[0], baselineComponent, kTolStrict);
+    EXPECT_NEAR(rectifiedTranslation[1], 0.0, kTolStrict);
+    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTolStrict);
 
-    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTol);
+    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTolStrict);
 }
 
 TEST(GeometryTest, StereoRectifyVerticalBaseline)
@@ -338,35 +345,35 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
 
     StereoRectify(K1, D1, K2, D2, 1024, 768, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
-    ExpectOrthonormal(rectifiedRotationFirst, kTol);
-    ExpectOrthonormal(rectifiedRotationSecond, kTol);
+    ExpectOrthonormal(rectifiedRotationFirst, kTolStrict);
+    ExpectOrthonormal(rectifiedRotationSecond, kTolStrict);
 
     const double offsetX = projectionSecond[0][3];
     const double offsetY = projectionSecond[1][3];
     EXPECT_GT(std::fabs(offsetY), std::fabs(offsetX));
-    EXPECT_NEAR(offsetX, 0.0, kTol);
+    EXPECT_NEAR(offsetX, 0.0, kTolStrict);
     const double expectedFocal = (K1.fx + K2.fx) * 0.5;
 
-    EXPECT_NEAR(projectionFirst[0][0], expectedFocal, kTol);
-    EXPECT_NEAR(projectionFirst[1][1], expectedFocal, kTol);
-    EXPECT_NEAR(projectionSecond[0][0], expectedFocal, kTol);
-    EXPECT_NEAR(projectionSecond[1][1], expectedFocal, kTol);
+    EXPECT_NEAR(projectionFirst[0][0], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][1], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionSecond[0][0], expectedFocal, kTolStrict);
+    EXPECT_NEAR(projectionSecond[1][1], expectedFocal, kTolStrict);
 
-    EXPECT_NEAR(projectionFirst[0][2], projectionSecond[0][2], kTol);
-    EXPECT_NEAR(projectionFirst[1][2], projectionSecond[1][2], kTol);
-    EXPECT_NEAR(projectionFirst[0][2], -reprojectionMatrix[0][3], kTol);
-    EXPECT_NEAR(projectionFirst[1][2], -reprojectionMatrix[1][3], kTol);
-    EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTol);
+    EXPECT_NEAR(projectionFirst[0][2], projectionSecond[0][2], kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][2], projectionSecond[1][2], kTolStrict);
+    EXPECT_NEAR(projectionFirst[0][2], -reprojectionMatrix[0][3], kTolStrict);
+    EXPECT_NEAR(projectionFirst[1][2], -reprojectionMatrix[1][3], kTolStrict);
+    EXPECT_NEAR(reprojectionMatrix[2][3], expectedFocal, kTolStrict);
 
     const double translationOffset = offsetY;
-    ASSERT_GT(std::fabs(translationOffset), kTol);
+    ASSERT_GT(std::fabs(translationOffset), kTolStrict);
     const double baselineComponent = translationOffset / expectedFocal;
     const retinify::Vec3d rectifiedTranslation = retinify::Multiply(rectifiedRotationSecond, translationVector);
-    EXPECT_NEAR(rectifiedTranslation[1], baselineComponent, kTol);
-    EXPECT_NEAR(rectifiedTranslation[0], 0.0, kTol);
-    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTol);
+    EXPECT_NEAR(rectifiedTranslation[1], baselineComponent, kTolStrict);
+    EXPECT_NEAR(rectifiedTranslation[0], 0.0, kTolStrict);
+    EXPECT_NEAR(rectifiedTranslation[2], 0.0, kTolStrict);
 
-    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTol);
+    EXPECT_NEAR(reprojectionMatrix[3][2], -1.0 / baselineComponent, kTolStrict);
 }
 
 TEST(GeometryTest, InitUndistortRectifyMapIdentity)
@@ -406,8 +413,8 @@ TEST(GeometryTest, InitUndistortRectifyMapIdentity)
         const auto *mapYRow = static_cast<const float *>(static_cast<const void *>(mapYBytes + offsetY));
         for (int u = 0; u < kWidth; ++u)
         {
-            EXPECT_NEAR(mapXRow[u], static_cast<float>(u), kTol);
-            EXPECT_NEAR(mapYRow[u], static_cast<float>(v), kTol);
+            EXPECT_NEAR(mapXRow[u], static_cast<float>(u), kTolStrict);
+            EXPECT_NEAR(mapYRow[u], static_cast<float>(v), kTolStrict);
         }
     }
 }
@@ -458,8 +465,8 @@ TEST(GeometryTest, InitUndistortRectifyMapRotatedCamera)
             const double expectedX = intrinsics.fx * normalizedX + intrinsics.skew * normalizedY + intrinsics.cx;
             const double expectedY = intrinsics.fy * normalizedY + intrinsics.cy;
 
-            EXPECT_NEAR(mapXRow[u], static_cast<float>(expectedX), kTol);
-            EXPECT_NEAR(mapYRow[u], static_cast<float>(expectedY), kTol);
+            EXPECT_NEAR(mapXRow[u], static_cast<float>(expectedX), kTolStrict);
+            EXPECT_NEAR(mapYRow[u], static_cast<float>(expectedY), kTolStrict);
         }
     }
 }
@@ -507,9 +514,201 @@ TEST(GeometryTest, InitUndistortRectifyMapAppliesDistortion)
             const Point2d idealPixel{rectifiedX, rectifiedY};
             const Point2d distortedPixel = DistortPoint(intrinsics, distortion, idealPixel);
 
-            EXPECT_NEAR(mapXRow[u], static_cast<float>(distortedPixel[0]), kTol);
-            EXPECT_NEAR(mapYRow[u], static_cast<float>(distortedPixel[1]), kTol);
+            EXPECT_NEAR(mapXRow[u], static_cast<float>(distortedPixel[0]), kTolStrict);
+            EXPECT_NEAR(mapYRow[u], static_cast<float>(distortedPixel[1]), kTolStrict);
         }
     }
+}
+
+namespace
+{
+auto ToCvCameraMatrix(const Intrinsics &intrinsics) -> cv::Mat
+{
+    cv::Mat cameraMatrix = cv::Mat::eye(3, 3, CV_64F);
+    cameraMatrix.at<double>(0, 0) = intrinsics.fx;
+    cameraMatrix.at<double>(0, 1) = intrinsics.skew;
+    cameraMatrix.at<double>(0, 2) = intrinsics.cx;
+    cameraMatrix.at<double>(1, 1) = intrinsics.fy;
+    cameraMatrix.at<double>(1, 2) = intrinsics.cy;
+    return cameraMatrix;
+}
+
+auto ToCvDistCoeffs(const Distortion &distortion) -> cv::Mat
+{
+    cv::Mat distCoeffs = cv::Mat::zeros(1, 8, CV_64F);
+    distCoeffs.at<double>(0, 0) = distortion.k1;
+    distCoeffs.at<double>(0, 1) = distortion.k2;
+    distCoeffs.at<double>(0, 2) = distortion.p1;
+    distCoeffs.at<double>(0, 3) = distortion.p2;
+    distCoeffs.at<double>(0, 4) = distortion.k3;
+    distCoeffs.at<double>(0, 5) = distortion.k4;
+    distCoeffs.at<double>(0, 6) = distortion.k5;
+    distCoeffs.at<double>(0, 7) = distortion.k6;
+    return distCoeffs;
+}
+
+auto ToCvRotation(const Mat3x3d &rotation) -> cv::Mat
+{
+    cv::Mat cvRotation(3, 3, CV_64F);
+    for (int r = 0; r < 3; ++r)
+    {
+        for (int c = 0; c < 3; ++c)
+        {
+            cvRotation.at<double>(r, c) = rotation[r][c];
+        }
+    }
+    return cvRotation;
+}
+
+auto ToCvTranslation(const Vec3d &translation) -> cv::Mat
+{
+    cv::Mat cvTranslation(3, 1, CV_64F);
+    for (int r = 0; r < 3; ++r)
+    {
+        cvTranslation.at<double>(r, 0) = translation[r];
+    }
+    return cvTranslation;
+}
+
+auto ToMat33d(const cv::Mat &cvMat) -> Mat3x3d
+{
+    Mat3x3d result{};
+    for (int r = 0; r < 3; ++r)
+    {
+        for (int c = 0; c < 3; ++c)
+        {
+            result[r][c] = cvMat.at<double>(r, c);
+        }
+    }
+    return result;
+}
+
+auto ToMat34d(const cv::Mat &cvMat) -> Mat3x4d
+{
+    Mat3x4d result{};
+    for (int r = 0; r < 3; ++r)
+    {
+        for (int c = 0; c < 4; ++c)
+        {
+            result[r][c] = cvMat.at<double>(r, c);
+        }
+    }
+    return result;
+}
+
+auto ToMat44d(const cv::Mat &cvMat) -> Mat4x4d
+{
+    Mat4x4d result{};
+    for (int r = 0; r < 4; ++r)
+    {
+        for (int c = 0; c < 4; ++c)
+        {
+            result[r][c] = cvMat.at<double>(r, c);
+        }
+    }
+    return result;
+}
+} // namespace
+
+TEST(GeometryTest, StereoRectifyMatchesOpenCV)
+{
+    const Intrinsics intrinsics1{615.0, 605.0, 321.5, 242.0, 0.0};
+    const Intrinsics intrinsics2{590.0, 600.0, 318.0, 239.5, 0.0};
+    const Distortion distortion1{0.011, -0.004, 5e-4, -3e-4, 7e-4, -2e-4, 1e-4, -5e-5};
+    const Distortion distortion2{-0.009, 0.0035, -4e-4, 2.5e-4, -6e-4, 1.5e-4, -8e-5, 4e-5};
+
+    const Mat3x3d rotation = Exp({0.08, -0.06, 0.04});
+    const Vec3d translation{0.12, 0.035, -0.018};
+
+    Mat3x3d rotation1{};
+    Mat3x3d rotation2{};
+    Mat3x4d projectionMatrix1{};
+    Mat3x4d projectionMatrix2{};
+    Mat4x4d mappingMatrix{};
+
+    StereoRectify(intrinsics1, distortion1, intrinsics2, distortion2, 960, 720, rotation, translation, rotation1, rotation2, projectionMatrix1, projectionMatrix2, mappingMatrix);
+
+    const cv::Mat cameraMatrix1 = ToCvCameraMatrix(intrinsics1);
+    const cv::Mat cameraMatrix2 = ToCvCameraMatrix(intrinsics2);
+    const cv::Mat distCoeffs1 = ToCvDistCoeffs(distortion1);
+    const cv::Mat distCoeffs2 = ToCvDistCoeffs(distortion2);
+    const cv::Mat cvRotation = ToCvRotation(rotation);
+    const cv::Mat cvTranslation = ToCvTranslation(translation);
+
+    cv::Mat cvR1;
+    cv::Mat cvR2;
+    cv::Mat cvP1;
+    cv::Mat cvP2;
+    cv::Mat cvQ;
+
+    cv::stereoRectify(cameraMatrix1, distCoeffs1, cameraMatrix2, distCoeffs2, cv::Size(960, 720), cvRotation, cvTranslation, cvR1, cvR2, cvP1, cvP2, cvQ, cv::CALIB_ZERO_DISPARITY, -1);
+
+    const Mat3x3d expectedR1 = ToMat33d(cvR1);
+    const Mat3x3d expectedR2 = ToMat33d(cvR2);
+    const Mat3x4d expectedP1 = ToMat34d(cvP1);
+    const Mat3x4d expectedP2 = ToMat34d(cvP2);
+    const Mat4x4d expectedQ = ToMat44d(cvQ);
+
+    ExpectMatrixNear(rotation1, expectedR1, kTolLoose);
+    ExpectMatrixNear(rotation2, expectedR2, kTolLoose);
+    ExpectMatrix34Near(projectionMatrix1, expectedP1, kTolLoose);
+    ExpectMatrix34Near(projectionMatrix2, expectedP2, kTolLoose);
+    ExpectMatrix44Near(mappingMatrix, expectedQ, kTolLoose);
+}
+
+TEST(GeometryTest, InitUndistortRectifyMapMatchesOpenCV)
+{
+    const Intrinsics intrinsics{612.5, 598.0, 322.0, 241.5, 0.0};
+    const Distortion distortion{-0.013, 0.0045, -6e-4, 3.5e-4, -7.5e-4, 2e-4, -1.1e-4, 6e-5};
+
+    const Mat3x3d rectificationRotation = Exp({-0.02, 0.015, 0.03});
+    Mat3x4d projection{};
+    projection[0] = {580.0, 0.0, 315.0, 0.0};
+    projection[1] = {0.0, 582.0, 238.0, 0.0};
+    projection[2] = {0.0, 0.0, 1.0, 0.0};
+
+    constexpr int kWidth = 64;
+    constexpr int kHeight = 48;
+
+    Mat mapX;
+    Mat mapY;
+    ASSERT_TRUE(mapX.Allocate(kHeight, kWidth, 1, sizeof(float), MatLocation::HOST).IsOK());
+    ASSERT_TRUE(mapY.Allocate(kHeight, kWidth, 1, sizeof(float), MatLocation::HOST).IsOK());
+
+    InitUndistortRectifyMap(intrinsics, distortion, rectificationRotation, projection, kWidth, kHeight, static_cast<float *>(mapX.Data()), mapX.Stride(), static_cast<float *>(mapY.Data()), mapY.Stride());
+
+    const cv::Mat cameraMatrix = ToCvCameraMatrix(intrinsics);
+    const cv::Mat distCoeffs = ToCvDistCoeffs(distortion);
+    const cv::Mat cvRectification = ToCvRotation(rectificationRotation);
+    cv::Mat cvNewCameraMatrix = cv::Mat::eye(3, 3, CV_64F);
+    cvNewCameraMatrix.at<double>(0, 0) = projection[0][0];
+    cvNewCameraMatrix.at<double>(1, 1) = projection[1][1];
+    cvNewCameraMatrix.at<double>(0, 2) = projection[0][2];
+    cvNewCameraMatrix.at<double>(1, 2) = projection[1][2];
+
+    cv::Mat cvMapX;
+    cv::Mat cvMapY;
+    cv::initUndistortRectifyMap(cameraMatrix, distCoeffs, cvRectification, cvNewCameraMatrix, cv::Size(kWidth, kHeight), CV_32FC1, cvMapX, cvMapY);
+
+    const auto *mapXBytes = static_cast<const std::byte *>(mapX.Data());
+    const auto *mapYBytes = static_cast<const std::byte *>(mapY.Data());
+
+    double maxErrorX = 0.0;
+    double maxErrorY = 0.0;
+    for (int v = 0; v < kHeight; ++v)
+    {
+        const auto *rowX = static_cast<const float *>(static_cast<const void *>(mapXBytes + static_cast<std::size_t>(v) * mapX.Stride()));
+        const auto *rowY = static_cast<const float *>(static_cast<const void *>(mapYBytes + static_cast<std::size_t>(v) * mapY.Stride()));
+        for (int u = 0; u < kWidth; ++u)
+        {
+            const double diffX = std::fabs(static_cast<double>(rowX[u]) - cvMapX.at<float>(v, u));
+            const double diffY = std::fabs(static_cast<double>(rowY[u]) - cvMapY.at<float>(v, u));
+            maxErrorX = std::max(maxErrorX, diffX);
+            maxErrorY = std::max(maxErrorY, diffY);
+        }
+    }
+
+    EXPECT_LT(maxErrorX, kTolLoose);
+    EXPECT_LT(maxErrorY, kTolLoose);
 }
 } // namespace retinify


### PR DESCRIPTION
Improve the clarity and consistency of function parameters in stereo rectification and undistortion functions. Rename parameters for better understanding and maintainability.