### PR TITLE
Refactor image width and height parameters for type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cv::Mat disparity = cv::Mat::zeros(leftImage.size(), CV_32FC1);
 retinify::Pipeline pipeline;
 
 // INITIALIZE THE PIPELINE
-pipeline.Initialize(leftImage.cols, leftImage.rows);
+pipeline.Initialize(static_cast<std::uint32_t>(leftImage.cols), static_cast<std::uint32_t>(leftImage.rows));
 
 // EXECUTE STEREO MATCHING
 pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0],   //

--- a/docs/content/tutorials.md
+++ b/docs/content/tutorials.md
@@ -71,7 +71,7 @@ cv::Mat disparity = cv::Mat::zeros(leftImage.size(), CV_32FC1);
 retinify::Pipeline pipeline;
 
 // INITIALIZE THE PIPELINE
-auto statusInitialize = pipeline.Initialize(leftImage.cols, leftImage.rows);
+auto statusInitialize = pipeline.Initialize(static_cast<std::uint32_t>(leftImage.cols), static_cast<std::uint32_t>(leftImage.rows));
 if (!statusInitialize.IsOK())
 {
     return 1;
@@ -85,7 +85,7 @@ if (!statusRun.IsOK())
 }
 
 // SHOW DISPARITY
-auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.rows, disparity.cols, 256.0F);
+auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
 if (!statusColorize.IsOK())
 {
     return 1;

--- a/retinify/include/retinify/colormap.hpp
+++ b/retinify/include/retinify/colormap.hpp
@@ -21,15 +21,14 @@ namespace retinify
 /// Output colored disparity map (8-bit 3-channel RGB).
 /// @param dstStride
 /// Stride of the output colored disparity map in bytes.
-/// @param height
-/// Height of the input and output disparity maps.
-/// @param width
+/// @param imageWidth
 /// Width of the input and output disparity maps.
-/// @param maxDisp
+/// @param imageHeight
+/// Height of the input and output disparity maps.
+/// @param maxDisparity
 /// Maximum disparity value for normalization.
 /// @return
 /// Status object indicating success or failure.
-RETINIFY_API auto ColorizeDisparity(const float *src, size_t srcStride, //
-                                    uint8_t *dst, size_t dstStride,     //
-                                    int height, int width, float maxDisp) -> Status;
+RETINIFY_API auto ColorizeDisparity(const float *src, size_t srcStride, uint8_t *dst, size_t dstStride, //
+                                    std::uint32_t imageWidth, std::uint32_t imageHeight, float maxDisparity) -> Status;
 } // namespace retinify

--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 namespace retinify
 {
@@ -181,6 +182,19 @@ struct DistortionFisheye
     double k4{0};
 };
 
+/// @brief Stereo camera calibration parameters.
+struct CalibrationParameters
+{
+    Intrinsics leftIntrinsics;    // Intrinsics for the left camera
+    Distortion leftDistortion;    // Distortion for the left camera
+    Intrinsics rightIntrinsics;   // Intrinsics for the right camera
+    Distortion rightDistortion;   // Distortion for the right camera
+    Mat3x3d rotation;             // Rotation from the left to the right camera
+    Vec3d translation;            // Translation from the left to the right camera
+    std::uint32_t imageWidth{0};  // Image width in pixels
+    std::uint32_t imageHeight{0}; // Image height in pixels
+};
+
 /// @brief
 /// Undistort a 2D point using the given camera intrinsics and distortion parameters.
 /// @param intrinsics
@@ -203,14 +217,14 @@ RETINIFY_API auto UndistortPoint(const Intrinsics &intrinsics, const Distortion 
 /// Second camera intrinsics.
 /// @param distortion2
 /// Second camera distortion.
-/// @param imageWidth
-/// Image width in pixels.
-/// @param imageHeight
-/// Image height in pixels.
 /// @param rotation
 /// Rotation from the first to the second camera.
 /// @param translation
 /// Translation from the first to the second camera.
+/// @param imageWidth
+/// Image width in pixels.
+/// @param imageHeight
+/// Image height in pixels.
 /// @param rotation1
 /// Output rectification rotation for the first camera.
 /// @param rotation2
@@ -223,8 +237,8 @@ RETINIFY_API auto UndistortPoint(const Intrinsics &intrinsics, const Distortion 
 /// Output mapping matrix.
 RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
                                 const Intrinsics &intrinsics2, const Distortion &distortion2, //
-                                int imageWidth, int imageHeight,                              //
                                 const Mat3x3d &rotation, const Vec3d &translation,            //
+                                std::uint32_t imageWidth, std::uint32_t imageHeight,          //
                                 Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
                                 Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
                                 Mat4x4d &mappingMatrix) noexcept -> void;
@@ -240,9 +254,9 @@ RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion 
 /// @param projectionMatrix
 /// Projection matrix
 /// @param imageWidth
-/// Image width
+/// Image width in pixels.
 /// @param imageHeight
-/// Image height
+/// Image height in pixels.
 /// @param mapx
 /// Output map for x-coordinates
 /// @param mapxStride
@@ -254,7 +268,7 @@ RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion 
 /// @return
 RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
                                           const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
-                                          int imageWidth, int imageHeight,                            //
+                                          std::uint32_t imageWidth, std::uint32_t imageHeight,        //
                                           float *mapx, std::size_t mapxStride,                        //
                                           float *mapy, std::size_t mapyStride) noexcept -> void;
 } // namespace retinify

--- a/retinify/include/retinify/pipeline.hpp
+++ b/retinify/include/retinify/pipeline.hpp
@@ -45,7 +45,7 @@ class RETINIFY_API Pipeline
     /// The mode option for the stereo matching.
     /// @return
     /// A Status object indicating whether the initialization was successful.
-    [[nodiscard]] auto Initialize(std::size_t imageWidth, std::size_t imageHeight, //
+    [[nodiscard]] auto Initialize(std::uint32_t imageWidth, std::uint32_t imageHeight, //
                                   Mode mode = Mode::ACCURATE) noexcept -> Status;
 
     /// @brief

--- a/retinify/src/geometry.cpp
+++ b/retinify/src/geometry.cpp
@@ -359,8 +359,8 @@ static auto BuildProjectionMatrix(double focal, const Point2d &principal) noexce
 
 auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
                    const Intrinsics &intrinsics2, const Distortion &distortion2, //
-                   int imageWidth, int imageHeight,                              //
                    const Mat3x3d &rotation, const Vec3d &translation,            //
+                   std::uint32_t imageWidth, std::uint32_t imageHeight,          //
                    Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
                    Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
                    Mat4x4d &mappingMatrix) noexcept -> void
@@ -412,7 +412,7 @@ auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1,
 
 auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
                              const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
-                             int imageWidth, int imageHeight,                            //
+                             std::uint32_t imageWidth, std::uint32_t imageHeight,        //
                              float *mapx, std::size_t mapxStride,                        //
                              float *mapy, std::size_t mapyStride) noexcept -> void
 {
@@ -432,14 +432,14 @@ auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &dis
     auto *mapxBytes = static_cast<unsigned char *>(static_cast<void *>(mapx));
     auto *mapyBytes = static_cast<unsigned char *>(static_cast<void *>(mapy));
 
-    for (int v = 0; v < imageHeight; ++v)
+    for (std::uint32_t v = 0; v < imageHeight; ++v)
     {
         const std::size_t offsetX = static_cast<std::size_t>(v) * mapxStride;
         const std::size_t offsetY = static_cast<std::size_t>(v) * mapyStride;
         auto *mapxRow = static_cast<float *>(static_cast<void *>(mapxBytes + offsetX));
         auto *mapyRow = static_cast<float *>(static_cast<void *>(mapyBytes + offsetY));
         const double rectifiedY = (static_cast<double>(v) - rectifiedPrincipalY) * invRectifiedFocalY;
-        for (int u = 0; u < imageWidth; ++u)
+        for (std::uint32_t u = 0; u < imageWidth; ++u)
         {
             const double rectifiedX = (static_cast<double>(u) - rectifiedPrincipalX) * invRectifiedFocalX;
             const Vec3d rectifiedPoint{rectifiedX, rectifiedY, 1.0};

--- a/retinify/src/pipeline.cpp
+++ b/retinify/src/pipeline.cpp
@@ -46,7 +46,7 @@ class Pipeline::Impl
     Impl(Impl &&) noexcept = delete;
     auto operator=(Impl &&other) noexcept -> Impl & = delete;
 
-    auto Initialize(const std::size_t imageWidth, const std::size_t imageHeight, //
+    auto Initialize(const std::uint32_t imageWidth, const std::uint32_t imageHeight, //
                     const Mode mode) noexcept -> Status
     {
         Status status;
@@ -58,8 +58,8 @@ class Pipeline::Impl
             return status;
         }
 
-        imageWidth_ = imageWidth;
-        imageHeight_ = imageHeight;
+        imageWidth_ = static_cast<std::size_t>(imageWidth);
+        imageHeight_ = static_cast<std::size_t>(imageHeight);
 
         switch (mode)
         {
@@ -475,7 +475,7 @@ auto Pipeline::impl() const noexcept -> const Impl *
     return std::launder(reinterpret_cast<const Impl *>(&buffer_)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 }
 
-auto Pipeline::Initialize(std::size_t imageWidth, std::size_t imageHeight, Mode mode) noexcept -> Status
+auto Pipeline::Initialize(const std::uint32_t imageWidth, const std::uint32_t imageHeight, Mode mode) noexcept -> Status
 {
     return this->impl()->Initialize(imageWidth, imageHeight, mode);
 }

--- a/retinify/tests/geometry_test.cpp
+++ b/retinify/tests/geometry_test.cpp
@@ -250,7 +250,7 @@ TEST(GeometryTest, StereoRectifyIdealRig)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(primaryIntrinsics, noDistortion, secondaryIntrinsics, noDistortion, 640, 480, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
+    StereoRectify(primaryIntrinsics, noDistortion, secondaryIntrinsics, noDistortion, rotationMatrix, translationVector, 640, 480, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
     ExpectMatrixNear(rectifiedRotationFirst, Identity(), kTolStrict);
     ExpectMatrixNear(rectifiedRotationSecond, Identity(), kTolStrict);
@@ -294,7 +294,7 @@ TEST(GeometryTest, StereoRectifyHorizontalBaseline)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(K1, D1, K2, D2, 800, 600, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
+    StereoRectify(K1, D1, K2, D2, rotationMatrix, translationVector, 800, 600, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
     ExpectOrthonormal(rectifiedRotationFirst, kTolStrict);
     ExpectOrthonormal(rectifiedRotationSecond, kTolStrict);
@@ -343,7 +343,7 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
     retinify::Mat3x4d projectionSecond{};
     retinify::Mat4x4d reprojectionMatrix{};
 
-    StereoRectify(K1, D1, K2, D2, 1024, 768, rotationMatrix, translationVector, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
+    StereoRectify(K1, D1, K2, D2, rotationMatrix, translationVector, 1024, 768, rectifiedRotationFirst, rectifiedRotationSecond, projectionFirst, projectionSecond, reprojectionMatrix);
 
     ExpectOrthonormal(rectifiedRotationFirst, kTolStrict);
     ExpectOrthonormal(rectifiedRotationSecond, kTolStrict);
@@ -626,7 +626,7 @@ TEST(GeometryTest, StereoRectifyMatchesOpenCV)
     Mat3x4d projectionMatrix2{};
     Mat4x4d mappingMatrix{};
 
-    StereoRectify(intrinsics1, distortion1, intrinsics2, distortion2, 960, 720, rotation, translation, rotation1, rotation2, projectionMatrix1, projectionMatrix2, mappingMatrix);
+    StereoRectify(intrinsics1, distortion1, intrinsics2, distortion2, rotation, translation, 960, 720, rotation1, rotation2, projectionMatrix1, projectionMatrix2, mappingMatrix);
 
     const cv::Mat cameraMatrix1 = ToCvCameraMatrix(intrinsics1);
     const cv::Mat cameraMatrix2 = ToCvCameraMatrix(intrinsics2);

--- a/retinify/tests/pipeline_test.cpp
+++ b/retinify/tests/pipeline_test.cpp
@@ -10,8 +10,8 @@ namespace retinify
 {
 TEST(PipelineTest, Forward)
 {
-    const int height = 720;
-    const int width = 1280;
+    const std::uint32_t width = 1280;
+    const std::uint32_t height = 720;
     cv::Mat left = cv::Mat::zeros(height, width, CV_8UC3);
     cv::Mat right = cv::Mat::zeros(height, width, CV_8UC3);
     cv::Mat disp = cv::Mat::zeros(height, width, CV_32FC1);

--- a/samples/inference/main.cpp
+++ b/samples/inference/main.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     cv::Mat disparity = cv::Mat::zeros(leftImage.size(), CV_32FC1);
     cv::Mat disparityColored = cv::Mat::zeros(leftImage.size(), CV_8UC3);
 
-    auto statusInitialize = pipeline.Initialize(leftImage.cols, leftImage.rows);
+    auto statusInitialize = pipeline.Initialize(static_cast<std::uint32_t>(leftImage.cols), static_cast<std::uint32_t>(leftImage.rows));
     if (!statusInitialize.IsOK())
     {
         retinify::LogError("Failed to initialize the pipeline.");
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.rows, disparity.cols, 256.0F);
+    auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
     if (!statusColorize.IsOK())
     {
         retinify::LogError("Failed to colorize the disparity map.");

--- a/samples/latency/main.cpp
+++ b/samples/latency/main.cpp
@@ -17,7 +17,7 @@ static constexpr int kBenchmarkNumIters = 10000;
 double BenchmarkPipeline(retinify::Mode mode, const cv::Mat &img0, const cv::Mat &img1, cv::Mat &disp, int num_iters = 10000)
 {
     retinify::Pipeline pipeline;
-    retinify::Status statusInitialize = pipeline.Initialize(kBenchmarkImageWidth, kBenchmarkImageHeight, mode);
+    retinify::Status statusInitialize = pipeline.Initialize(static_cast<std::uint32_t>(kBenchmarkImageWidth), static_cast<std::uint32_t>(kBenchmarkImageHeight), mode);
     if (!statusInitialize.IsOK())
     {
         retinify::LogError("Pipeline initialization failed for mode.");


### PR DESCRIPTION
Update image width and height parameters to use `std::uint32_t` for improved consistency and type safety throughout the codebase.