### PR TITLE
Refactor pointer types to std::uint8_t for type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cv::Mat disparity = cv::Mat::zeros(leftImage.size(), CV_32FC1);
 retinify::Pipeline pipeline;
 
 // INITIALIZE THE PIPELINE
-pipeline.Initialize(static_cast<std::uint32_t>(leftImage.cols), static_cast<std::uint32_t>(leftImage.rows));
+pipeline.Initialize(leftImage.cols, leftImage.rows);
 
 // EXECUTE STEREO MATCHING
 pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0],   //

--- a/docs/content/tutorials.md
+++ b/docs/content/tutorials.md
@@ -78,14 +78,14 @@ if (!statusInitialize.IsOK())
 }
 
 // EXECUTE STEREO MATCHING
-auto statusRun = pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0], rightImage.ptr<uint8_t>(), rightImage.step[0], disparity.ptr<float>(), disparity.step[0]);
+auto statusRun = pipeline.Run(leftImage.ptr<std::uint8_t>(), leftImage.step[0], rightImage.ptr<std::uint8_t>(), rightImage.step[0], disparity.ptr<float>(), disparity.step[0]);
 if (!statusRun.IsOK())
 {
     return 1;
 }
 
 // SHOW DISPARITY
-auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
+auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<std::uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
 if (!statusColorize.IsOK())
 {
     return 1;

--- a/retinify/include/retinify/colormap.hpp
+++ b/retinify/include/retinify/colormap.hpp
@@ -29,6 +29,6 @@ namespace retinify
 /// Maximum disparity value for normalization.
 /// @return
 /// Status object indicating success or failure.
-RETINIFY_API auto ColorizeDisparity(const float *src, size_t srcStride, uint8_t *dst, size_t dstStride, //
+RETINIFY_API auto ColorizeDisparity(const float *src, std::size_t srcStride, std::uint8_t *dst, std::size_t dstStride, //
                                     std::uint32_t imageWidth, std::uint32_t imageHeight, float maxDisparity) -> Status;
 } // namespace retinify

--- a/retinify/src/colormap.cpp
+++ b/retinify/src/colormap.cpp
@@ -9,7 +9,7 @@
 
 namespace retinify
 {
-static constexpr uint8_t TURBO_LUT[256][3] = {
+static constexpr std::uint8_t TURBO_LUT[256][3] = {
     {48, 18, 59},   {50, 21, 67},   {51, 24, 74},    {52, 27, 81},    //
     {53, 30, 88},   {54, 33, 95},   {55, 36, 102},   {56, 39, 109},   //
     {57, 42, 115},  {58, 45, 121},  {59, 47, 128},   {60, 50, 134},   //
@@ -76,7 +76,7 @@ static constexpr uint8_t TURBO_LUT[256][3] = {
     {133, 7, 2},    {129, 6, 2},    {126, 5, 2},     {122, 4, 3}      //
 };
 
-auto ColorizeDisparity(const float *src, size_t srcStride, uint8_t *dst, size_t dstStride, std::uint32_t imageWidth, std::uint32_t imageHeight, float maxDisparity) -> Status
+auto ColorizeDisparity(const float *src, std::size_t srcStride, std::uint8_t *dst, std::size_t dstStride, std::uint32_t imageWidth, std::uint32_t imageHeight, float maxDisparity) -> Status
 {
     if (src == nullptr || dst == nullptr)
     {
@@ -96,8 +96,8 @@ auto ColorizeDisparity(const float *src, size_t srcStride, uint8_t *dst, size_t 
         return Status{StatusCategory::USER, StatusCode::INVALID_ARGUMENT};
     }
 
-    const auto requiredSrcStride = static_cast<size_t>(imageWidth) * sizeof(float);
-    const auto requiredDstStride = static_cast<size_t>(imageWidth) * 3 * sizeof(std::uint8_t);
+    const auto requiredSrcStride = static_cast<std::size_t>(imageWidth) * sizeof(float);
+    const auto requiredDstStride = static_cast<std::size_t>(imageWidth) * 3 * sizeof(std::uint8_t);
 
     if ((srcStride < requiredSrcStride) || (dstStride < requiredDstStride))
     {
@@ -111,13 +111,13 @@ auto ColorizeDisparity(const float *src, size_t srcStride, uint8_t *dst, size_t 
         return Status{StatusCategory::USER, StatusCode::INVALID_ARGUMENT};
     }
 
-    const size_t srcStrideInFloats = srcStride / sizeof(float);
+    const std::size_t srcStrideInFloats = srcStride / sizeof(float);
 
     for (std::uint32_t y = 0; y < imageHeight; ++y)
     {
-        const size_t rowIndex = static_cast<size_t>(y);
+        const std::size_t rowIndex = static_cast<std::size_t>(y);
         const float *srcRow = src + rowIndex * srcStrideInFloats;
-        uint8_t *dstRow = dst + rowIndex * dstStride;
+        std::uint8_t *dstRow = dst + rowIndex * dstStride;
 
         for (std::uint32_t x = 0; x < imageWidth; ++x)
         {

--- a/retinify/src/pipeline.cpp
+++ b/retinify/src/pipeline.cpp
@@ -428,28 +428,28 @@ class Pipeline::Impl
     }
 
   private:
-    bool initialized_{false};     // whether the pipeline is initialized
-    Stream stream_;               // stream for operations
-    size_t imageWidth_{0};        // original input image width
-    size_t imageHeight_{0};       // original input image height
-    size_t matchingHeight_{0};    // image height for stereo matching
-    size_t matchingWidth_{0};     // image width for stereo matching
-    Session session_;             // inference session
-    Mat left8UC3_;                // input rgb image
-    Mat right8UC3_;               // input rgb image
-    Mat leftDisparity32FC1_;      // output left disparity map
-    Mat leftResized8UC3_;         // resized rgb image
-    Mat rightResized8UC3_;        // resized rgb image
-    Mat leftResized8UC1_;         // resized gray image
-    Mat rightResized8UC1_;        // resized gray image
-    Mat leftResized32FC1_;        // resized gray image for stereo matching
-    Mat rightResized32FC1_;       // resized gray image for stereo matching
-    Mat disparityResized32FC1_;   // resized disparity map from stereo matching
-    Mat leftFliped8UC3_;          // input gray image (fliped)
-    Mat rightFliped8UC3_;         // input gray image (fliped)
-    Mat disparityFliped32FC1_;    // output disparity map (fliped)
-    Mat rightDisparity32FC1_;     // output right disparity map
-    Mat lrCheckedDisparity32FC1_; // output disparity map after left-right consistency check
+    bool initialized_{false};       // whether the pipeline is initialized
+    Stream stream_;                 // stream for operations
+    std::size_t imageWidth_{0};     // original input image width
+    std::size_t imageHeight_{0};    // original input image height
+    std::size_t matchingHeight_{0}; // image height for stereo matching
+    std::size_t matchingWidth_{0};  // image width for stereo matching
+    Session session_;               // inference session
+    Mat left8UC3_;                  // input rgb image
+    Mat right8UC3_;                 // input rgb image
+    Mat leftDisparity32FC1_;        // output left disparity map
+    Mat leftResized8UC3_;           // resized rgb image
+    Mat rightResized8UC3_;          // resized rgb image
+    Mat leftResized8UC1_;           // resized gray image
+    Mat rightResized8UC1_;          // resized gray image
+    Mat leftResized32FC1_;          // resized gray image for stereo matching
+    Mat rightResized32FC1_;         // resized gray image for stereo matching
+    Mat disparityResized32FC1_;     // resized disparity map from stereo matching
+    Mat leftFliped8UC3_;            // input gray image (fliped)
+    Mat rightFliped8UC3_;           // input gray image (fliped)
+    Mat disparityFliped32FC1_;      // output disparity map (fliped)
+    Mat rightDisparity32FC1_;       // output right disparity map
+    Mat lrCheckedDisparity32FC1_;   // output disparity map after left-right consistency check
 };
 
 Pipeline::Pipeline() noexcept

--- a/samples/inference/main.cpp
+++ b/samples/inference/main.cpp
@@ -40,9 +40,9 @@ int main(int argc, char **argv)
     }
 
     const float kMaxRelativeDisparityError = 0.05F;
-    auto statusRun = pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0],   //
-                                  rightImage.ptr<uint8_t>(), rightImage.step[0], //
-                                  disparity.ptr<float>(), disparity.step[0],     //
+    auto statusRun = pipeline.Run(leftImage.ptr<std::uint8_t>(), leftImage.step[0],   //
+                                  rightImage.ptr<std::uint8_t>(), rightImage.step[0], //
+                                  disparity.ptr<float>(), disparity.step[0],          //
                                   kMaxRelativeDisparityError);
     if (!statusRun.IsOK())
     {
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
+    auto statusColorize = retinify::ColorizeDisparity(disparity.ptr<float>(), disparity.step[0], disparityColored.ptr<std::uint8_t>(), disparityColored.step[0], disparity.cols, disparity.rows, 256.0F);
     if (!statusColorize.IsOK())
     {
         retinify::LogError("Failed to colorize the disparity map.");


### PR DESCRIPTION
Update pointer types to std::uint8_t across the codebase to enhance consistency and type safety. This change improves code clarity and reduces potential type-related issues.