### PR TITLE
Refactor CUDA integration and enhance type safety in lrcheck module

### DIFF
--- a/docs/content/tutorials.md
+++ b/docs/content/tutorials.md
@@ -44,13 +44,10 @@ Upon successful execution, the result will be displayed and a file named `dispar
   
 ## 4. Create a retinify project
 We recommend using a CMake-based project when integrating retinify.  
-Retinify requires **C++20** and **GCC 11 or later**.  
+Retinify requires **GCC 11 or later**.  
 ```cmake
-set(CMAKE_CXX_STANDARD 20)
-
 find_package(retinify REQUIRED)
-
-target_link_libraries(${PROJECT_NAME} retinify)
+target_link_libraries(${PROJECT_NAME} retinify::retinify)
 ```
 
 In this tutorial, we will use image data in the form of `cv::Mat`.  

--- a/retinify/CMakeLists.txt
+++ b/retinify/CMakeLists.txt
@@ -5,13 +5,6 @@ file(GLOB SRCS_CXX
     ./include/*.hpp
 )
 
-# CUDA SOURCES
-if (BUILD_WITH_TENSORRT)
-    enable_language(CUDA)
-    file(GLOB SRCS_CUDA ./src/cuda/*.cu ./src/cuda/*.h)
-    list(APPEND SRCS_CXX ${SRCS_CUDA})
-endif()
-
 # LIBRARY
 add_library(retinify SHARED ${SRCS_CXX})
 set_target_properties(retinify PROPERTIES
@@ -30,9 +23,18 @@ target_include_directories(retinify
 
 # SETTINGS
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+
+set_target_properties(retinify 
+    PROPERTIES
+        CXX_EXTENSIONS OFF
+)
+
+target_compile_features(retinify 
+    PUBLIC 
+        cxx_std_20
+)
+
 target_compile_options(retinify
-    PUBLIC
-        $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
     PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:-fvisibility=hidden>
         $<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>
@@ -42,31 +44,14 @@ target_compile_options(retinify
 )
 
 if(BUILD_WITH_TENSORRT)
-    set_target_properties(retinify PROPERTIES
-        CUDA_ARCHITECTURES "75;80;86;87;89"
-    )
+    add_subdirectory(src/cuda)
+    target_link_libraries(retinify PRIVATE retinify-cuda)
 
-    target_compile_options(retinify
-        PRIVATE
-            $<$<COMPILE_LANGUAGE:CUDA>:-std=c++17>
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fvisibility=hidden>
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fvisibility-inlines-hidden>
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-funroll-loops>
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fno-rtti>
-            $<$<COMPILE_LANGUAGE:CUDA>:-O3>
-            $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
-            $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>
-            $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>
-    )
-endif()
+    target_compile_definitions(retinify PRIVATE BUILD_WITH_TENSORRT)
 
-# DEPENDENCIES
-if(BUILD_WITH_TENSORRT)
-    target_compile_definitions(retinify PUBLIC BUILD_WITH_TENSORRT)
-
-    target_include_directories(retinify PUBLIC /usr/local/cuda/include)
+    target_include_directories(retinify PRIVATE /usr/local/cuda/include)
     target_link_libraries(retinify
-        PUBLIC
+        PRIVATE
             /usr/local/cuda/lib64/libcudart.so
             /usr/local/cuda/lib64/libnppc.so
             /usr/local/cuda/lib64/libnppidei.so
@@ -110,9 +95,8 @@ if(BUILD_WITH_TENSORRT)
         )
         message(STATUS "TensorRT linked (${CMAKE_SYSTEM_PROCESSOR})")
     else()
-        message(WARNING "TensorRT libraries not found (${CMAKE_SYSTEM_PROCESSOR})")
+        message(FATAL_ERROR "TensorRT libraries not found (${CMAKE_SYSTEM_PROCESSOR})")
     endif()
-else()
 endif()
 
 # INSTALL

--- a/retinify/src/cuda/CMakeLists.txt
+++ b/retinify/src/cuda/CMakeLists.txt
@@ -1,0 +1,31 @@
+enable_language(CUDA)
+set(CMAKE_CUDA_ARCHITECTURES 75 80 86 87 89 90 100)
+
+file(GLOB SRCS_CUDA
+    lrcheck.cu
+    lrcheck.h
+)
+
+add_library(retinify-cuda STATIC ${SRCS_CUDA})
+
+set_target_properties(retinify-cuda PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+
+target_include_directories(retinify-cuda
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_compile_options(retinify-cuda
+    PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:-std=c++17>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fvisibility=hidden>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fvisibility-inlines-hidden>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-funroll-loops>
+        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fno-rtti>
+        $<$<COMPILE_LANGUAGE:CUDA>:-O3>
+        $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>
+        $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>
+        $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>
+)

--- a/retinify/src/cuda/lrcheck.cu
+++ b/retinify/src/cuda/lrcheck.cu
@@ -4,6 +4,7 @@
 #include "lrcheck.h"
 
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cuda_runtime.h>
 
@@ -16,7 +17,7 @@
 
 namespace retinify
 {
-static inline int DivUpInt(int a, int b)
+static inline std::uint32_t DivUpUint32(std::uint32_t a, std::uint32_t b)
 {
     return (a + b - 1) / b;
 }
@@ -24,11 +25,11 @@ static inline int DivUpInt(int a, int b)
 __global__ void LRConsistencyCheckKernel(const float *__restrict__ leftDisparity, std::size_t leftDisparityStride,   //
                                          const float *__restrict__ rightDisparity, std::size_t rightDisparityStride, //
                                          float *__restrict__ outputDisparity, std::size_t outputDisparityStride,     //
-                                         int disparityWidth, int disparityHeight,                                    //
+                                         std::uint32_t disparityWidth, std::uint32_t disparityHeight,                //
                                          float maxRelativeDisparityError)
 {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    const std::uint32_t x = static_cast<std::uint32_t>(blockIdx.x) * static_cast<std::uint32_t>(blockDim.x) + static_cast<std::uint32_t>(threadIdx.x);
+    const std::uint32_t y = static_cast<std::uint32_t>(blockIdx.y) * static_cast<std::uint32_t>(blockDim.y) + static_cast<std::uint32_t>(threadIdx.y);
 
     if (x >= disparityWidth || y >= disparityHeight)
     {
@@ -47,18 +48,22 @@ __global__ void LRConsistencyCheckKernel(const float *__restrict__ leftDisparity
     const float ld = leftRow[x];
     if (ld > 0.0f && isfinite(ld))
     {
-        const int rx = x - static_cast<int>(ld + 0.5f);
-        if (rx >= 0 && rx < disparityWidth)
+        const std::uint32_t roundedLd = static_cast<std::uint32_t>(ld + 0.5f);
+        if (roundedLd <= x)
         {
-            const float rd = rightRow[rx];
-            if (isfinite(rd))
+            const std::uint32_t rx = x - roundedLd;
+            if (rx < disparityWidth)
             {
-                const float absDiff = fabsf(ld - rd);
-                const float avgd = 0.5f * (fabsf(ld) + fabsf(rd));
-                const float relativeDiff = absDiff / avgd;
-                if (relativeDiff <= maxRelativeDisparityError)
+                const float rd = rightRow[rx];
+                if (isfinite(rd))
                 {
-                    outputVal = ld;
+                    const float absDiff = fabsf(ld - rd);
+                    const float avgd = 0.5f * (fabsf(ld) + fabsf(rd));
+                    const float relativeDiff = absDiff / avgd;
+                    if (relativeDiff <= maxRelativeDisparityError)
+                    {
+                        outputVal = ld;
+                    }
                 }
             }
         }
@@ -70,7 +75,7 @@ __global__ void LRConsistencyCheckKernel(const float *__restrict__ leftDisparity
 cudaError_t cudaLRConsistencyCheck(const float *leftDisparity, std::size_t leftDisparityStride,   //
                                    const float *rightDisparity, std::size_t rightDisparityStride, //
                                    float *outputDisparity, std::size_t outputDisparityStride,     //
-                                   int disparityWidth, int disparityHeight,                       //
+                                   std::uint32_t disparityWidth, std::uint32_t disparityHeight,   //
                                    float maxRelativeDisparityError,                               //
                                    cudaStream_t stream)
 {
@@ -80,7 +85,7 @@ cudaError_t cudaLRConsistencyCheck(const float *leftDisparity, std::size_t leftD
         return cudaErrorInvalidValue;
     }
 
-    if (disparityWidth <= 0 || disparityHeight <= 0)
+    if (disparityWidth == 0 || disparityHeight == 0)
     {
         std::printf("Input size must be positive.\n");
         return cudaErrorInvalidValue;
@@ -99,7 +104,9 @@ cudaError_t cudaLRConsistencyCheck(const float *leftDisparity, std::size_t leftD
     }
 
     dim3 block(LRCC_BLOCK_W, LRCC_BLOCK_H, 1);
-    dim3 grid(DivUpInt(disparityWidth, block.x), DivUpInt(disparityHeight, block.y), 1);
+    const std::uint32_t gridX = DivUpUint32(disparityWidth, static_cast<std::uint32_t>(block.x));
+    const std::uint32_t gridY = DivUpUint32(disparityHeight, static_cast<std::uint32_t>(block.y));
+    dim3 grid(gridX, gridY, 1);
 
     LRConsistencyCheckKernel<<<grid, block, 0, stream>>>(leftDisparity, leftDisparityStride,     //
                                                          rightDisparity, rightDisparityStride,   //

--- a/retinify/src/cuda/lrcheck.h
+++ b/retinify/src/cuda/lrcheck.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <cuda_runtime.h>
 
 namespace retinify
@@ -11,7 +12,7 @@ namespace retinify
 cudaError_t cudaLRConsistencyCheck(const float *leftDisparity, std::size_t leftDisparityStride,   //
                                    const float *rightDisparity, std::size_t rightDisparityStride, //
                                    float *outputDisparity, std::size_t outputDisparityStride,     //
-                                   int disparityWidth, int disparityHeight,                       //
+                                   std::uint32_t disparityWidth, std::uint32_t disparityHeight,   //
                                    float maxRelativeDisparityError,                               //
                                    cudaStream_t stream);
 } // namespace retinify


### PR DESCRIPTION
Update the CUDA integration in the lrcheck module to improve type safety by replacing integer types with unsigned integers. This change enhances the clarity and correctness of the code while maintaining compatibility with existing functionality. Additionally, streamline the CMake configuration for better management of CUDA sources.