### PR TITLE
Refactor CUDA integration and improve type safety in lrcheck module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
 ﻿# CMAKE
 cmake_minimum_required(VERSION 3.22)
-message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
-set(CMAKE_BUILD_TYPE Release)
+
+# BUILD OPTIONS
+option(BUILD_WITH_TENSORRT "Build with TensorRT" ON)
+option(BUILD_SAMPLES "Build samples" ON)
+option(BUILD_TESTS "Build tests" ON)
 
 # PROJECT
-project(retinify)
+if(BUILD_WITH_TENSORRT)
+    message(STATUS "BUILD_WITH_TENSORRT=ON -> enabling CXX and CUDA languages")
+    project(retinify LANGUAGES CXX CUDA)
+else()
+    project(retinify LANGUAGES CXX)
+endif()
+set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_INSTALL_PREFIX "/usr")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -34,11 +43,6 @@ configure_package_config_file(
 install(FILES "${CMAKE_BINARY_DIR}/retinifyConfig.cmake"
     DESTINATION "lib/cmake/retinify"
 )
-
-# BUILD OPTIONS
-option(BUILD_WITH_TENSORRT "Build with TensorRT" ON)
-option(BUILD_SAMPLES "Build samples" ON)
-option(BUILD_TESTS "Build tests" ON)
 
 # ALL IN ONE HEADER
 set(LIBRETINIFY_OPTION_INCLUDES "")

--- a/retinify/src/cuda/CMakeLists.txt
+++ b/retinify/src/cuda/CMakeLists.txt
@@ -1,4 +1,3 @@
-enable_language(CUDA)
 set(CMAKE_CUDA_ARCHITECTURES 75 80 86 87 89 90)
 
 file(GLOB SRCS_CUDA


### PR DESCRIPTION
Enhance CUDA integration and type safety in the lrcheck module by updating CMake configurations, removing unsupported architectures, and reorganizing settings for clarity. Adjustments ensure compatibility with newer CUDA versions and improve overall project structure.