### PR TITLE
Remove unnecessary CUDA::cuda_driver link from retinify library

### DIFF
--- a/retinify/CMakeLists.txt
+++ b/retinify/CMakeLists.txt
@@ -55,7 +55,6 @@ if(BUILD_WITH_TENSORRT)
     target_link_libraries(retinify
         PUBLIC
             CUDA::cudart
-            CUDA::cuda_driver
             CUDA::nppc
             CUDA::nppidei
             CUDA::nppicc


### PR DESCRIPTION
Eliminate the redundant link to CUDA::cuda_driver in the retinify library to streamline dependencies.