### PR TITLE
Change CUDA library link visibility to PRIVATE in CMakeLists

### DIFF
--- a/retinify/CMakeLists.txt
+++ b/retinify/CMakeLists.txt
@@ -47,13 +47,13 @@ if(BUILD_WITH_TENSORRT)
     )
 
     target_compile_definitions(retinify 
-        PUBLIC 
+        PRIVATE 
             BUILD_WITH_TENSORRT
     )
 
     find_package(CUDAToolkit REQUIRED)
     target_link_libraries(retinify
-        PUBLIC
+        PRIVATE
             CUDA::cudart
             CUDA::nppc
             CUDA::nppidei

--- a/retinify/src/cuda/CMakeLists.txt
+++ b/retinify/src/cuda/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(retinify-cuda STATIC ${SRCS_CUDA})
 
 find_package(CUDAToolkit REQUIRED)
 target_link_libraries(retinify-cuda
-    PUBLIC
+    PRIVATE
         CUDA::cudart
 )
 

--- a/retinify/tests/CMakeLists.txt
+++ b/retinify/tests/CMakeLists.txt
@@ -12,6 +12,20 @@ target_link_libraries(retinify-tests
     PUBLIC retinify ${OpenCV_LIBS} gtest gtest_main
 )
 
+# BUILD OPTIONS
+if(BUILD_WITH_TENSORRT)
+    target_compile_definitions(retinify-tests 
+        PUBLIC 
+            BUILD_WITH_TENSORRT
+    )
+
+    find_package(CUDAToolkit REQUIRED)
+    target_link_libraries(retinify-tests
+        PRIVATE
+            CUDA::cudart
+    )
+endif()
+
 # INCLUDES
 target_include_directories(retinify-tests
     PRIVATE 


### PR DESCRIPTION
Adjust the visibility of CUDA library links in CMakeLists to PRIVATE for better encapsulation and to prevent unintended usage in other targets.