### PR TITLE
Add EULA handling and update installation paths

### DIFF
--- a/.github/workflows/build-tensorrt10-jetpack6.yml
+++ b/.github/workflows/build-tensorrt10-jetpack6.yml
@@ -61,6 +61,7 @@ jobs:
             git config --global --add safe.directory /workspace/3rdparty/glfw            
             git config --global --add safe.directory /workspace/3rdparty/googletest
             git config --global --add safe.directory /workspace/3rdparty/imgui
+            git config --global --add safe.directory /workspace/3rdparty/retinify-EULA
             git submodule sync --recursive
             git submodule update --init --recursive
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rdparty/glfw"]
 	path = 3rdparty/glfw
 	url = https://github.com/glfw/glfw.git
+[submodule "3rdparty/retinify-EULA"]
+	path = 3rdparty/retinify-EULA
+	url = https://github.com/retinify/retinify-EULA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,23 @@
 ﻿# CMAKE
 cmake_minimum_required(VERSION 3.22)
 
+# EULA
+set(RETINIFY_EULA_DIR "${CMAKE_SOURCE_DIR}/3rdparty/retinify-EULA")
+set(RETINIFY_EULA_FILE "${RETINIFY_EULA_DIR}/EULA.md")
+find_program(GIT_EXECUTABLE git REQUIRED)
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive -- 3rdparty/retinify-EULA
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(COMMAND "${GIT_EXECUTABLE}" -C "${RETINIFY_EULA_DIR}" fetch origin main COMMAND_ERROR_IS_FATAL ANY)
+execute_process(COMMAND "${GIT_EXECUTABLE}" -C "${RETINIFY_EULA_DIR}" reset --hard origin/main COMMAND_ERROR_IS_FATAL ANY)
+
+if(NOT EXISTS "${RETINIFY_EULA_FILE}")
+  message(FATAL_ERROR "EULA not found: ${RETINIFY_EULA_FILE}")
+endif()
+
 # BUILD OPTIONS
 option(BUILD_WITH_TENSORRT "Build with TensorRT" ON)
 option(BUILD_SAMPLES "Build samples" ON)
@@ -98,7 +115,7 @@ if(BUILD_SAMPLES)
 endif(BUILD_SAMPLES)
 
 # SHARE
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md DESTINATION share/retinify)
+install(FILES ${RETINIFY_EULA_FILE} DESTINATION share/retinify)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE.md DESTINATION share/retinify)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/VERSION DESTINATION share/retinify)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/weights/${PROJECT_VERSION}/model.onnx DESTINATION share/retinify/weights/${PROJECT_VERSION})
@@ -124,7 +141,7 @@ set(CPACK_PACKAGE_DESCRIPTION "Real-Time AI Stereo Vision Library")
 set(CPACK_DEBIAN_PACKAGE_SECTION "libs")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://retinify.ai")
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${RETINIFY_EULA_FILE}")
 include(CPack)
 
 # MESSAGES
@@ -136,4 +153,5 @@ message(STATUS "BUILD_WITH_TENSORRT    : ${BUILD_WITH_TENSORRT}")
 message(STATUS "BUILD_SAMPLES          : ${BUILD_SAMPLES}")
 message(STATUS "BUILD_TESTS            : ${BUILD_TESTS}")
 message(STATUS "STEREO_MODEL_PATH      : ${STEREO_MODEL_PATH}")
+message(STATUS "EULA_PATH              : ${RETINIFY_EULA_FILE}")
 message(STATUS "================================================================================")

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,5 @@
-Use of retinify is governed by the then-current [**retinify End User License Agreement**](https://github.com/retinify/retinify-EULA/blob/main/EULA.md).
+Use of **retinify** is governed by the current [**retinify End User License Agreement**](https://github.com/retinify/retinify-EULA/blob/main/EULA.md).  
+By cloning, building, installing, or using retinify, you agree to the EULA.  
+If you do not agree, you must not use or update retinify.  
+
+For common questions, see the [**FAQ**](https://github.com/retinify/retinify-EULA/blob/main/FAQ.md).  


### PR DESCRIPTION
Introduce EULA handling by adding the retinify-EULA submodule and updating installation paths in CMake. Include additional usage terms and a FAQ link in the LICENSE.md file. Configure safe.directory for the submodule to ensure proper handling.