### PR TITLE
Add safe.directory configuration for retinify-EULA submodule in build workflows

### DIFF
--- a/.github/workflows/build-tensorrt10-cuda12.yml
+++ b/.github/workflows/build-tensorrt10-cuda12.yml
@@ -44,6 +44,7 @@ jobs:
             apt update && apt install -y git cmake build-essential
 
             git config --global --add safe.directory /workspace
+            git config --global --add safe.directory /workspace/3rdparty/retinify-EULA
             git submodule update --init --recursive
 
             ./build.sh --install --tensorrt

--- a/.github/workflows/build-tensorrt10-cuda13.yml
+++ b/.github/workflows/build-tensorrt10-cuda13.yml
@@ -44,6 +44,7 @@ jobs:
             apt update && apt install -y git cmake build-essential
 
             git config --global --add safe.directory /workspace
+            git config --global --add safe.directory /workspace/3rdparty/retinify-EULA
             git submodule update --init --recursive
 
             ./build.sh --install --tensorrt


### PR DESCRIPTION
Include the safe.directory configuration for the retinify-EULA submodule to ensure proper handling during build workflows.