### PR TITLE
Add EULA acceptance option to build script

### DIFF
--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Build RETINIFY
       run: |
-        ./build.sh --install --cpu
+        ./build.sh --install --cpu --accept-eula

--- a/.github/workflows/build-tensorrt10-cuda12.yml
+++ b/.github/workflows/build-tensorrt10-cuda12.yml
@@ -47,5 +47,5 @@ jobs:
             git config --global --add safe.directory /workspace/3rdparty/retinify-EULA
             git submodule update --init --recursive
 
-            ./build.sh --install --tensorrt
+            ./build.sh --install --tensorrt --accept-eula
           "

--- a/.github/workflows/build-tensorrt10-cuda13.yml
+++ b/.github/workflows/build-tensorrt10-cuda13.yml
@@ -47,5 +47,5 @@ jobs:
             git config --global --add safe.directory /workspace/3rdparty/retinify-EULA
             git submodule update --init --recursive
 
-            ./build.sh --install --tensorrt
+            ./build.sh --install --tensorrt --accept-eula
           "

--- a/.github/workflows/build-tensorrt10-jetpack6.yml
+++ b/.github/workflows/build-tensorrt10-jetpack6.yml
@@ -65,5 +65,5 @@ jobs:
             git submodule sync --recursive
             git submodule update --init --recursive
 
-            ./build.sh --install --tensorrt
+            ./build.sh --install --tensorrt --accept-eula
           "

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ BUILD_WITH_TENSORRT=ON
 BUILD_SAMPLES=OFF
 BUILD_TESTS=OFF
 DO_INSTALL=0
+ACCEPT_EULA=0
 
 # ARGUMENTS
 for arg in "$@"; do
@@ -25,13 +26,64 @@ for arg in "$@"; do
             BUILD_SAMPLES=ON
             BUILD_TESTS=ON
             ;;
+        --accept-eula)
+            ACCEPT_EULA=1
+            ;;
         *)
             echo "Unknown option: $arg"
-            echo "Usage: $0 [--install] [--tensorrt|--cpu] [--dev]"
+            echo "Usage: $0 [--install] [--tensorrt|--cpu] [--dev] [--accept-eula]"
             exit 1
             ;;
     esac
 done
+
+# EULA ACCEPTANCE
+EULA_REPO="retinify/retinify-EULA"
+
+EULA_URL="https://github.com/${EULA_REPO}/blob/main/EULA.md"
+EULA_FAQ_URL="https://github.com/${EULA_REPO}/blob/main/FAQ.md"
+RAW_URL="https://raw.githubusercontent.com/${EULA_REPO}/main/EULA.md"
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+    echo -e "\033[1;31m\033[1m[RETINIFY] 'sha256sum' not found. Please install coreutils.\033[0m"
+    exit 1
+fi
+
+EULA_SHA256="$(curl -fsSL --retry 3 --retry-delay 1 --max-time 15 "${RAW_URL}" | sha256sum | cut -d' ' -f1 || true)"
+if [[ -z "${EULA_SHA256}" ]]; then
+    echo -e "\033[1;31m\033[1m[RETINIFY] Failed to get EULA checksum.\033[0m"
+    exit 1
+fi
+
+if [[ "${ACCEPT_EULA:-0}" == "1" ]]; then
+    echo -e "\033[1;32m\033[1m[RETINIFY] EULA ACCEPTED VIA COMMAND LINE. CONTINUING BUILD.\033[0m"
+else
+    echo "----------------------------------------------------------------------"
+    echo -e "\033[1;32m[RETINIFY] End User License Agreement (EULA)\033[0m"
+    echo "EULA Text : ${EULA_URL}"
+    echo "FAQ       : ${EULA_FAQ_URL}"
+    echo "Checksum  : ${EULA_SHA256}"
+    echo "----------------------------------------------------------------------"
+    echo "By typing 'yes', you confirm that you have read and agree to the full"
+    echo "text of the retinify End User License Agreement (EULA)."
+    echo "If you do not agree, the build process will be aborted."
+    echo "----------------------------------------------------------------------"
+
+    if [[ ! -t 0 ]]; then
+        echo -e "\033[1;31m\033[1m[RETINIFY] No TTY and no non-interactive acceptance provided. Aborting.\033[0m"
+        exit 3
+    fi
+    read -r -p "Do you accept the retinify End User License Agreement? [yes/no]: " ans
+    case "${ans}" in
+        yes)
+            echo -e "\033[1;32m[RETINIFY] EULA ACCEPTED. CONTINUING BUILD.\033[0m"
+            ;;
+        *)
+            echo -e "\033[1;31m\033[1m[RETINIFY] EULA NOT ACCEPTED. ABORTING BUILD.\033[0m"
+            exit 1
+            ;;
+    esac
+fi
 
 # BUILD
 echo -e "\033[1;32m[RETINIFY] STARTING BUILD PROCESS\033[0m"


### PR DESCRIPTION
Introduce an option to accept the End User License Agreement (EULA) in the build script, allowing for both command line acceptance and interactive prompts. This change enhances the build process for RETINIFY by ensuring compliance with EULA requirements.