### PR TITLE
Refactor ONNX model references for stereo matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,32 +75,12 @@ install(
 )
 
 # ONNX MODEL
-set(STEREO_MODEL_URL  "https://github.com/retinify/retinify-models/releases/download/v${PROJECT_VERSION}/model.onnx")
-set(STEREO_MODEL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/weights/${PROJECT_VERSION}/model.onnx")
-set(STEREO_MODEL_HASH_URL  "${STEREO_MODEL_URL}.sha256")
-set(STEREO_MODEL_HASH_PATH  "${STEREO_MODEL_PATH}.sha256")
+set(STEREO_MODEL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/weights/stereo-matching.onnx")
+if(NOT EXISTS "${STEREO_MODEL_PATH}")
+  message(FATAL_ERROR "Stereo model file not found: ${STEREO_MODEL_PATH}")
+endif()
 
-file(DOWNLOAD
-    "${STEREO_MODEL_HASH_URL}"
-    "${STEREO_MODEL_HASH_PATH}"
-    TLS_VERIFY ON
-    STATUS status
-)
-
-file(READ "${STEREO_MODEL_HASH_PATH}" STEREO_MODEL_HASH_RAW)
-string(REGEX MATCH "^[0-9a-fA-F]+" STEREO_MODEL_HASH_HEX "${STEREO_MODEL_HASH_RAW}")
-set(STEREO_MODEL_HASH_EXPECTED "SHA256=${STEREO_MODEL_HASH_HEX}")
-
-file(DOWNLOAD
-    "${STEREO_MODEL_URL}"
-    "${STEREO_MODEL_PATH}"
-    EXPECTED_HASH "${STEREO_MODEL_HASH_EXPECTED}"
-    SHOW_PROGRESS
-    TLS_VERIFY ON
-    STATUS status
-)
-
-set(LIBRETINIFY_ONNX_PATH "${CMAKE_INSTALL_PREFIX}/share/retinify/weights/${PROJECT_VERSION}/model.onnx")
+set(STEREO_MATCHING_ONNX_PATH "${CMAKE_INSTALL_PREFIX}/share/retinify/weights/${PROJECT_VERSION}/stereo-matching.onnx")
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/retinify_onnx.hpp.in"
     "${CMAKE_BINARY_DIR}/include/retinify/retinify_onnx.hpp"
@@ -118,7 +98,7 @@ endif(BUILD_SAMPLES)
 install(FILES ${RETINIFY_EULA_FILE} DESTINATION share/retinify)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/NOTICE.md DESTINATION share/retinify)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/VERSION DESTINATION share/retinify)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/weights/${PROJECT_VERSION}/model.onnx DESTINATION share/retinify/weights/${PROJECT_VERSION})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/weights/stereo-matching.onnx DESTINATION share/retinify/weights/${PROJECT_VERSION})
 
 # CPACK
 set(CPACK_GENERATOR "DEB")

--- a/cmake/retinify_onnx.hpp.in
+++ b/cmake/retinify_onnx.hpp.in
@@ -3,4 +3,4 @@
 
 #pragma once
 
-inline constexpr const char *LIBRETINIFY_ONNX_PATH = "@LIBRETINIFY_ONNX_PATH@";
+inline constexpr const char *STEREO_MATCHING_ONNX_PATH = "@STEREO_MATCHING_ONNX_PATH@";

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -19,6 +19,15 @@ git clone --recurse-submodules https://github.com/retinify/retinify.git
 cd retinify
 ```
 
+## Download Weights
+Download `stereo-matching.onnx` from [Hugging Face](https://huggingface.co/retinify/stereo-matching)  
+and place it inside the `weights` directory within the cloned `retinify` folder, as shown below:
+```
+retinify/
+└── weights/
+    └── stereo-matching.onnx
+```
+
 ## Install retinify
 Build retinify and install its Debian package.
 ```bash

--- a/retinify/include/retinify/paths.hpp
+++ b/retinify/include/retinify/paths.hpp
@@ -27,7 +27,7 @@ RETINIFY_API auto DataDirectoryPath() noexcept -> const char *;
 /// @return A null-terminated string with the state directory path, or nullptr on failure.
 RETINIFY_API auto StateDirectoryPath() noexcept -> const char *;
 
-/// @brief Returns the path to the ONNX model file used by retinify.
+/// @brief Returns the path to the ONNX model file used for stereo matching.
 /// @return A null-terminated string with the ONNX model file path.
-RETINIFY_API auto ONNXModelFilePath() noexcept -> const char *;
+RETINIFY_API auto StereoMatchingOnnxFilePath() noexcept -> const char *;
 } // namespace retinify

--- a/retinify/src/paths.cpp
+++ b/retinify/src/paths.cpp
@@ -128,8 +128,8 @@ auto StateDirectoryPath() noexcept -> const char *
     return ResolveUserDirectory(kStateDirName, "Failed to create or access the state directory.");
 }
 
-auto ONNXModelFilePath() noexcept -> const char *
+auto StereoMatchingOnnxFilePath() noexcept -> const char *
 {
-    return LIBRETINIFY_ONNX_PATH;
+    return STEREO_MATCHING_ONNX_PATH;
 }
 } // namespace retinify

--- a/retinify/src/pipeline.cpp
+++ b/retinify/src/pipeline.cpp
@@ -328,7 +328,7 @@ class Pipeline::Impl
             return status;
         }
 
-        status = session_.Initialize(ONNXModelFilePath());
+        status = session_.Initialize(StereoMatchingOnnxFilePath());
         if (!status.IsOK())
         {
             return status;

--- a/retinify/tests/paths_test.cpp
+++ b/retinify/tests/paths_test.cpp
@@ -63,8 +63,8 @@ TEST_F(PathTest, StateDirectoryPath)
     CheckPath(StateDirectoryPath(), true);
 }
 
-TEST_F(PathTest, ONNXModelFilePath)
+TEST_F(PathTest, StereoMatchingOnnxFilePath)
 {
-    CheckPath(ONNXModelFilePath(), false);
+    CheckPath(StereoMatchingOnnxFilePath(), false);
 }
 } // namespace retinify


### PR DESCRIPTION
Rename ONNX model references to reflect stereo matching and update related paths. Add instructions for downloading the stereo-matching.onnx weights.