### PR TITLE
Update hf-download action for new Hugging Face CLI commands

### DIFF
--- a/.github/actions/hf-download/action.yml
+++ b/.github/actions/hf-download/action.yml
@@ -17,14 +17,13 @@ runs:
         HF_TOKEN: ${{ inputs.token }}
       run: |
         set -e
-
-        python -m pip install -q "huggingface_hub[cli]"
+        python -m pip install -q "huggingface_hub[cli]>=0.25.0"
 
         echo "Logging in to Hugging Face..."
-        huggingface-cli login --token "${HF_TOKEN}" --add-to-git-credential
+        hf auth login --token "${HF_TOKEN}" --add-to-git-credential
 
         echo "Downloading stereo-matching.onnx..."
         mkdir -p weights
-        huggingface-cli download retinify/stereo-matching stereo-matching.onnx \
-          --local-dir weights --local-dir-use-symlinks False
+        hf download retinify/stereo-matching stereo-matching.onnx --local-dir weights
+
         ls -lh weights

--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -22,7 +22,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: ./.github/actions/hf-download
+    - name: Download Weights
+      uses: ./.github/actions/hf-download
       with:
         token: ${{ secrets.HF_TOKEN }}
 

--- a/.github/workflows/build-tensorrt10-cuda12.yml
+++ b/.github/workflows/build-tensorrt10-cuda12.yml
@@ -22,7 +22,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: ./.github/actions/hf-download
+    - name: Download Weights
+      uses: ./.github/actions/hf-download
       with:
         token: ${{ secrets.HF_TOKEN }}
 

--- a/.github/workflows/build-tensorrt10-cuda13.yml
+++ b/.github/workflows/build-tensorrt10-cuda13.yml
@@ -22,7 +22,8 @@ jobs:
       with:
         submodules: true
 
-    - uses: ./.github/actions/hf-download
+    - name: Download Weights
+      uses: ./.github/actions/hf-download
       with:
         token: ${{ secrets.HF_TOKEN }}
 

--- a/.github/workflows/build-tensorrt10-jetpack6.yml
+++ b/.github/workflows/build-tensorrt10-jetpack6.yml
@@ -23,7 +23,8 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
-    - uses: ./.github/actions/hf-download
+    - name: Download Weights
+      uses: ./.github/actions/hf-download
       with:
         token: ${{ secrets.HF_TOKEN }}
 


### PR DESCRIPTION
Revise the hf-download action to utilize updated Hugging Face CLI commands and enforce a version constraint for the huggingface_hub package. Rename the action step for clarity.