### PR TITLE
Rename Run to Execute for consistency and add depth map functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
   />
 </a>
   
-# retinify
->Real-Time AI Stereo Vision Library
-  
 [![UBUNTU 24.04](https://img.shields.io/badge/-UBUNTU%2024%2E04-orange?style=flat-square&logo=ubuntu&logoColor=white)](https://releases.ubuntu.com/noble/)
 [![UBUNTU 22.04](https://img.shields.io/badge/-UBUNTU%2022%2E04-orange?style=flat-square&logo=ubuntu&logoColor=white)](https://releases.ubuntu.com/jammy/)
 [![JETPACK 6](https://img.shields.io/badge/-JETPACK%206-76B900?style=flat-square&logo=nvidia&logoColor=white)](https://docs.nvidia.com/jetson/jetpack/index.html)
@@ -18,6 +15,9 @@
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-@retinify-blue?style=flat-square&logo=linkedin)](https://www.linkedin.com/company/retinify)
 [![YouTube](https://img.shields.io/badge/Watch-%40retinify-red?style=flat-square&logo=youtube)](https://www.youtube.com/@retinify_ai)
   
+# retinify
+>Real-Time AI Stereo Vision Library
+
 Retinify is an advanced AI-powered stereo vision library designed for robotics. It enables real-time, high-precision 3D perception by leveraging GPU and NPU acceleration.  
   
 <table style="width:100%;">
@@ -63,9 +63,11 @@ retinify::Pipeline pipeline;
 pipeline.Initialize(leftImage.cols, leftImage.rows);
 
 // EXECUTE STEREO MATCHING
-pipeline.Run(leftImage.ptr<uint8_t>(), leftImage.step[0],   //
-             rightImage.ptr<uint8_t>(), rightImage.step[0], //
-             disparity.ptr<float>(), disparity.step[0]);
+pipeline.Execute(leftImage.ptr<uint8_t>(), leftImage.step[0],
+                 rightImage.ptr<uint8_t>(), rightImage.step[0]);
+
+// RETRIEVE DISPARITY
+pipeline.RetrieveDisparity(disparity.ptr<float>(), disparity.step[0]);
 ```
 
 ## Getting Started

--- a/docs/content/tutorials.md
+++ b/docs/content/tutorials.md
@@ -75,8 +75,15 @@ if (!statusInitialize.IsOK())
 }
 
 // EXECUTE STEREO MATCHING
-auto statusRun = pipeline.Run(leftImage.ptr<std::uint8_t>(), leftImage.step[0], rightImage.ptr<std::uint8_t>(), rightImage.step[0], disparity.ptr<float>(), disparity.step[0]);
-if (!statusRun.IsOK())
+auto statusExecute = pipeline.Execute(leftImage.ptr<std::uint8_t>(), leftImage.step[0], rightImage.ptr<std::uint8_t>(), rightImage.step[0]);
+if (!statusExecute.IsOK())
+{
+    return 1;
+}
+
+// RETRIEVE DISPARITY
+auto statusRetrieve = pipeline.RetrieveDisparity(disparity.ptr<float>(), disparity.step[0]);
+if (!statusRetrieve.IsOK())
 {
     return 1;
 }

--- a/retinify/include/retinify/pipeline.hpp
+++ b/retinify/include/retinify/pipeline.hpp
@@ -85,9 +85,25 @@ class RETINIFY_API Pipeline
     /// Stride (in bytes) of a row in the output disparity data.
     /// @return
     /// A Status object indicating whether the operation was successful.
+    RETINIFY_DEPRECATED("Use Execute() followed by RetrieveDisparity() instead.")
     [[nodiscard]] auto Run(const std::uint8_t *leftImageData, std::size_t leftImageStride,   //
                            const std::uint8_t *rightImageData, std::size_t rightImageStride, //
                            float *disparityData, std::size_t disparityStride) noexcept -> Status;
+
+    /// @brief
+    /// Executes the stereo matching pipeline using the given left and right image data.
+    /// @param leftImageData
+    /// Pointer to the left image data.
+    /// @param leftImageStride
+    /// Stride (in bytes) of a row in the left image.
+    /// @param rightImageData
+    /// Pointer to the right image data.
+    /// @param rightImageStride
+    /// Stride (in bytes) of a row in the right image.
+    /// @return
+    /// A Status object indicating whether the operation was successful.
+    [[nodiscard]] auto Execute(const std::uint8_t *leftImageData, std::size_t leftImageStride, //
+                               const std::uint8_t *rightImageData, std::size_t rightImageStride) noexcept -> Status;
 
     /// @brief
     /// Retrieves the rectified left image.
@@ -98,7 +114,7 @@ class RETINIFY_API Pipeline
     /// @return
     /// A Status object indicating whether the operation was successful.
     /// @note
-    /// This function must be called after Run().
+    /// This function must be called after Execute().
     [[nodiscard]] auto RetrieveRectifiedLeftImage(std::uint8_t *leftImageData, std::size_t leftImageStride) noexcept -> Status;
 
     /// @brief
@@ -110,7 +126,7 @@ class RETINIFY_API Pipeline
     /// @return
     /// A Status object indicating whether the operation was successful.
     /// @note
-    /// This function must be called after Run().
+    /// This function must be called after Execute().
     [[nodiscard]] auto RetrieveRectifiedRightImage(std::uint8_t *rightImageData, std::size_t rightImageStride) noexcept -> Status;
 
     /// @brief
@@ -126,7 +142,7 @@ class RETINIFY_API Pipeline
     /// @return
     /// A Status object indicating whether the operation was successful.
     /// @note
-    /// This function must be called after Run().
+    /// This function must be called after Execute().
     [[nodiscard]] auto RetrieveRectifiedImages(std::uint8_t *leftImageData, std::size_t leftImageStride, //
                                                std::uint8_t *rightImageData, std::size_t rightImageStride) noexcept -> Status;
 
@@ -139,7 +155,7 @@ class RETINIFY_API Pipeline
     /// @return
     /// A Status object indicating whether the operation was successful.
     /// @note
-    /// This function must be called after Run().
+    /// This function must be called after Execute().
     [[nodiscard]] auto RetrieveDisparity(float *disparityData, std::size_t disparityStride) noexcept -> Status;
 
     /// @brief
@@ -151,7 +167,7 @@ class RETINIFY_API Pipeline
     /// @return
     /// A Status object indicating whether the operation was successful.
     /// @note
-    /// This function must be called after Run().
+    /// This function must be called after Execute().
     [[nodiscard]] auto RetrievePointCloud(float *pointCloudData, std::size_t pointCloudStride) noexcept -> Status;
 
   private:

--- a/retinify/include/retinify/pipeline.hpp
+++ b/retinify/include/retinify/pipeline.hpp
@@ -159,6 +159,18 @@ class RETINIFY_API Pipeline
     [[nodiscard]] auto RetrieveDisparity(float *disparityData, std::size_t disparityStride) noexcept -> Status;
 
     /// @brief
+    /// Retrieves the computed depth map.
+    /// @param depthData
+    /// Pointer to the output buffer for depth data (32-bit float).
+    /// @param depthStride
+    /// Stride (in bytes) of a row in the output depth data.
+    /// @return
+    /// A Status object indicating whether the operation was successful.
+    /// @note
+    /// This function must be called after Execute().
+    [[nodiscard]] auto RetrieveDepth(float *depthData, std::size_t depthStride) noexcept -> Status;
+
+    /// @brief
     /// Reprojects the computed disparity map to a 3D point cloud.
     /// @param pointCloudData
     /// Pointer to the output buffer for point cloud data (32-bit float, 3 channels).

--- a/retinify/src/cuda/CMakeLists.txt
+++ b/retinify/src/cuda/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(CMAKE_CUDA_ARCHITECTURES 75 80 86 87 89 90)
 
 file(GLOB SRCS_CUDA
+    depth.cu
+    depth.h
     occlusion.cu
     occlusion.h
     lrcheck.cu

--- a/retinify/src/cuda/depth.cu
+++ b/retinify/src/cuda/depth.cu
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Sensui Yagi. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-retinify-eula
+
+#include "depth.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cuda_runtime.h>
+
+#ifndef DEPTH_BLOCK_W
+#define DEPTH_BLOCK_W 16
+#endif
+
+#ifndef DEPTH_BLOCK_H
+#define DEPTH_BLOCK_H 16
+#endif
+
+namespace retinify
+{
+namespace
+{
+struct Matrix4x4f
+{
+    float4 rows[4];
+};
+
+__device__ __forceinline__ float MultiplyRow(const Matrix4x4f &matrix, int row, float u, float v, float disparity)
+{
+    const float4 r = matrix.rows[row];
+    return (r.x * u) + (r.y * v) + (r.z * disparity) + r.w;
+}
+
+__host__ __device__ __forceinline__ std::uint32_t DivUp(std::uint32_t value, std::uint32_t divisor)
+{
+    return (value + divisor - 1U) / divisor;
+}
+} // namespace
+
+__global__ void DisparityToDepthKernel(const float *__restrict__ disparity, std::size_t disparityStride, //
+                                       float *__restrict__ depth, std::size_t depthStride,               //
+                                       std::uint32_t width, std::uint32_t height,                        //
+                                       Matrix4x4f reprojection)
+{
+    const std::uint32_t x = static_cast<std::uint32_t>(blockIdx.x) * static_cast<std::uint32_t>(blockDim.x) + static_cast<std::uint32_t>(threadIdx.x);
+    const std::uint32_t y = static_cast<std::uint32_t>(blockIdx.y) * static_cast<std::uint32_t>(blockDim.y) + static_cast<std::uint32_t>(threadIdx.y);
+
+    if (x >= width || y >= height)
+    {
+        return;
+    }
+
+    const std::size_t disparityRowOffset = (static_cast<std::size_t>(y) * disparityStride) / sizeof(float);
+    const std::size_t depthRowOffset = (static_cast<std::size_t>(y) * depthStride) / sizeof(float);
+
+    const float *disparityRow = disparity + disparityRowOffset;
+    float *depthRow = depth + depthRowOffset;
+
+    float outDepth = 0.0f;
+    const float disparityValue = disparityRow[x];
+
+    if (disparityValue > 0.0f && isfinite(disparityValue))
+    {
+        const float u = static_cast<float>(x);
+        const float v = static_cast<float>(y);
+
+        const float Z = MultiplyRow(reprojection, 2, u, v, disparityValue);
+        const float W = MultiplyRow(reprojection, 3, u, v, disparityValue);
+
+        if (fabsf(W) > 1e-6f)
+        {
+            outDepth = Z / W;
+        }
+    }
+
+    depthRow[x] = outDepth;
+}
+
+cudaError_t cudaDisparityToDepth(const float *disparity, std::size_t disparityStride, //
+                                 float *depth, std::size_t depthStride,               //
+                                 std::uint32_t width, std::uint32_t height,           //
+                                 const float *reprojectionQ,                          //
+                                 cudaStream_t stream)
+{
+    if (disparity == nullptr || depth == nullptr || reprojectionQ == nullptr)
+    {
+        std::printf("Input pointer is null.\n");
+        return cudaErrorInvalidValue;
+    }
+
+    if (width == 0U || height == 0U)
+    {
+        std::printf("Input size must be positive.\n");
+        return cudaErrorInvalidValue;
+    }
+
+    if ((disparityStride % sizeof(float)) != 0U || (depthStride % sizeof(float)) != 0U)
+    {
+        std::printf("Stride must be a multiple of sizeof(float).\n");
+        return cudaErrorInvalidValue;
+    }
+
+    const std::size_t requiredDisparityStride = static_cast<std::size_t>(width) * sizeof(float);
+    if (disparityStride < requiredDisparityStride)
+    {
+        std::printf("Disparity stride is too small.\n");
+        return cudaErrorInvalidValue;
+    }
+
+    const std::size_t requiredDepthStride = static_cast<std::size_t>(width) * sizeof(float);
+    if (depthStride < requiredDepthStride)
+    {
+        std::printf("Depth stride is too small.\n");
+        return cudaErrorInvalidValue;
+    }
+
+    Matrix4x4f matrix{};
+    matrix.rows[0] = make_float4(reprojectionQ[0], reprojectionQ[1], reprojectionQ[2], reprojectionQ[3]);
+    matrix.rows[1] = make_float4(reprojectionQ[4], reprojectionQ[5], reprojectionQ[6], reprojectionQ[7]);
+    matrix.rows[2] = make_float4(reprojectionQ[8], reprojectionQ[9], reprojectionQ[10], reprojectionQ[11]);
+    matrix.rows[3] = make_float4(reprojectionQ[12], reprojectionQ[13], reprojectionQ[14], reprojectionQ[15]);
+
+    dim3 block(DEPTH_BLOCK_W, DEPTH_BLOCK_H, 1);
+    dim3 grid(DivUp(width, static_cast<std::uint32_t>(block.x)), DivUp(height, static_cast<std::uint32_t>(block.y)), 1);
+
+    DisparityToDepthKernel<<<grid, block, 0, stream>>>(disparity, disparityStride, //
+                                                       depth, depthStride,         //
+                                                       width, height,              //
+                                                       matrix);
+
+    return cudaGetLastError();
+}
+} // namespace retinify

--- a/retinify/src/cuda/depth.h
+++ b/retinify/src/cuda/depth.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Sensui Yagi. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-retinify-eula
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace retinify
+{
+cudaError_t cudaDisparityToDepth(const float *disparity, std::size_t disparityStride, //
+                                 float *depth, std::size_t depthStride,               //
+                                 std::uint32_t width, std::uint32_t height,           //
+                                 const float *reprojectionQ,                          //
+                                 cudaStream_t stream);
+} // namespace retinify

--- a/retinify/src/imgproc.hpp
+++ b/retinify/src/imgproc.hpp
@@ -149,4 +149,18 @@ namespace retinify
 /// @return
 /// Status code.
 [[nodiscard]] auto ReprojectDisparityTo3D(const Mat &disparity, Mat &points3d, const Mat4x4d &Q, Stream &stream) noexcept -> Status;
+
+/// @brief
+/// Convert a disparity map into a depth map using a reprojection matrix.
+/// @param disparity
+/// Input disparity map (32-bit floating-point, 1-channel).
+/// @param depth
+/// Output depth map (32-bit floating-point, 1-channel).
+/// @param Q
+/// 4x4 reprojection matrix (row-major, double).
+/// @param stream
+/// Execution stream.
+/// @return
+/// Status code.
+[[nodiscard]] auto DisparityToDepth32FC1(const Mat &disparity, Mat &depth, const Mat4x4d &Q, Stream &stream) noexcept -> Status;
 } // namespace retinify

--- a/retinify/src/session.cpp
+++ b/retinify/src/session.cpp
@@ -292,7 +292,7 @@ auto Session::BindOutput(const char *name, const Mat &mat) const noexcept -> Sta
 #endif
 }
 
-auto Session::Run(Stream &stream) const noexcept -> Status
+auto Session::Execute(Stream &stream) const noexcept -> Status
 {
 #ifdef BUILD_WITH_TENSORRT
     if (!context_->allInputDimensionsSpecified())

--- a/retinify/src/session.hpp
+++ b/retinify/src/session.hpp
@@ -32,7 +32,7 @@ class RETINIFY_API Session
     [[nodiscard]] auto Initialize(const char *model_path) noexcept -> Status;
     [[nodiscard]] auto BindInput(const char *name, const Mat &mat) const noexcept -> Status;
     [[nodiscard]] auto BindOutput(const char *name, const Mat &mat) const noexcept -> Status;
-    [[nodiscard]] auto Run(Stream &stream) const noexcept -> Status;
+    [[nodiscard]] auto Execute(Stream &stream) const noexcept -> Status;
 
   private:
 #ifdef BUILD_WITH_TENSORRT

--- a/retinify/tests/pipeline_test.cpp
+++ b/retinify/tests/pipeline_test.cpp
@@ -21,8 +21,8 @@ void InitializeAndRunPipeline(Pipeline &pipeline, std::uint32_t width, std::uint
     Status stInit = pipeline.Initialize(width, height, pixelFormat, depthMode);
     ASSERT_TRUE(stInit.IsOK()) << "Initialize Failed";
 
-    Status stRun = pipeline.Run(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0], disparity.ptr<float>(), disparity.step[0]);
-    ASSERT_TRUE(stRun.IsOK()) << "Run Failed";
+    Status stExecute = pipeline.Execute(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0]);
+    ASSERT_TRUE(stExecute.IsOK()) << "Execute Failed";
 }
 } // namespace
 
@@ -39,8 +39,8 @@ TEST(PipelineTest, RunGray)
     Status stInit = pipeline.Initialize(width, height, PixelFormat::GRAY8, DepthMode::BALANCED);
     ASSERT_TRUE(stInit.IsOK()) << "Initialize Failed";
 
-    Status stRun = pipeline.Run(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0], disp.ptr<float>(), disp.step[0]);
-    ASSERT_TRUE(stRun.IsOK()) << "Run Failed";
+    Status stExecute = pipeline.Execute(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0]);
+    ASSERT_TRUE(stExecute.IsOK()) << "Execute Failed";
 }
 
 TEST(PipelineTest, RetrieveOutputsSuccess)
@@ -340,8 +340,8 @@ TEST(PipelineTest, RunRGB)
     Status stInit = pipeline.Initialize(width, height, PixelFormat::RGB8, DepthMode::BALANCED);
     ASSERT_TRUE(stInit.IsOK()) << "Initialize Failed";
 
-    Status stRun = pipeline.Run(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0], disp.ptr<float>(), disp.step[0]);
-    ASSERT_TRUE(stRun.IsOK()) << "Run Failed";
+    Status stExecute = pipeline.Execute(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0]);
+    ASSERT_TRUE(stExecute.IsOK()) << "Execute Failed";
 }
 
 TEST(PipelineTest, RunLowResolution)
@@ -357,8 +357,8 @@ TEST(PipelineTest, RunLowResolution)
     Status stInit = pipeline.Initialize(width, height, PixelFormat::RGB8, DepthMode::ACCURATE);
     ASSERT_TRUE(stInit.IsOK()) << "Initialize Failed";
 
-    Status stRun = pipeline.Run(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0], disp.ptr<float>(), disp.step[0]);
-    ASSERT_TRUE(stRun.IsOK()) << "Run Failed";
+    Status stExecute = pipeline.Execute(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0]);
+    ASSERT_TRUE(stExecute.IsOK()) << "Execute Failed";
 }
 
 TEST(PipelineTest, RunAccurateHighResolution)
@@ -374,7 +374,7 @@ TEST(PipelineTest, RunAccurateHighResolution)
     Status stInit = pipeline.Initialize(width, height, PixelFormat::RGB8, DepthMode::ACCURATE);
     ASSERT_TRUE(stInit.IsOK()) << "Initialize Failed";
 
-    Status stRun = pipeline.Run(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0], disp.ptr<float>(), disp.step[0]);
-    ASSERT_TRUE(stRun.IsOK()) << "Run Failed";
+    Status stExecute = pipeline.Execute(left.ptr<std::uint8_t>(), left.step[0], right.ptr<std::uint8_t>(), right.step[0]);
+    ASSERT_TRUE(stExecute.IsOK()) << "Execute Failed";
 }
 } // namespace retinify

--- a/samples/inference/main.cpp
+++ b/samples/inference/main.cpp
@@ -39,12 +39,18 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    auto statusRun = pipeline.Run(leftImage.ptr<std::uint8_t>(), leftImage.step[0],   //
-                                  rightImage.ptr<std::uint8_t>(), rightImage.step[0], //
-                                  disparity.ptr<float>(), disparity.step[0]);
-    if (!statusRun.IsOK())
+    auto statusExecute = pipeline.Execute(leftImage.ptr<std::uint8_t>(), leftImage.step[0], //
+                                          rightImage.ptr<std::uint8_t>(), rightImage.step[0]);
+    if (!statusExecute.IsOK())
     {
         retinify::LogError("Failed to run the pipeline.");
+        return 1;
+    }
+
+    auto statusRetrieve = pipeline.RetrieveDisparity(disparity.ptr<float>(), disparity.step[0]);
+    if (!statusRetrieve.IsOK())
+    {
+        retinify::LogError("Failed to retrieve the disparity map.");
         return 1;
     }
 

--- a/samples/latency/main.cpp
+++ b/samples/latency/main.cpp
@@ -30,12 +30,20 @@ double BenchmarkPipeline(retinify::DepthMode mode, const cv::Mat &img0, const cv
     for (int i = 0; i < num_iters; ++i)
     {
         auto start = std::chrono::high_resolution_clock::now();
-        retinify::Status statusRun = pipeline.Run(img0.ptr<std::uint8_t>(), img0.step[0], img1.ptr<std::uint8_t>(), img1.step[0], disp.ptr<float>(), disp.step[0]);
-        if (!statusRun.IsOK())
+        retinify::Status statusExecute = pipeline.Execute(img0.ptr<std::uint8_t>(), img0.step[0], img1.ptr<std::uint8_t>(), img1.step[0]);
+        if (!statusExecute.IsOK())
         {
-            retinify::LogError("Pipeline run failed for mode.");
+            retinify::LogError("Pipeline execution failed.");
             return -1.0;
         }
+
+        retinify::Status statusRetrieve = pipeline.RetrieveDisparity(disp.ptr<float>(), disp.step[0]);
+        if (!statusRetrieve.IsOK())
+        {
+            retinify::LogError("Disparity retrieval failed.");
+            return -1.0;
+        }
+
         auto end = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
         double ms = static_cast<double>(duration.count()) / 1000.0;


### PR DESCRIPTION
Refactor the code to replace instances of "Run" with "Execute" across various classes and examples for consistency. Introduce depth map retrieval functionality along with CUDA integration for disparity to depth conversion.