### PR TITLE
Refactor log level management to use atomic storage

### DIFF
--- a/retinify/src/logging.cpp
+++ b/retinify/src/logging.cpp
@@ -3,28 +3,30 @@
 
 #include "retinify/logging.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <source_location>
 #include <sstream>
 
 namespace retinify
 {
-static inline auto GetLogLevelRef() noexcept -> LogLevel &
+static inline auto GetLogLevelStorage() noexcept -> std::atomic<LogLevel> &
 {
-    static LogLevel level = LogLevel::INFO;
-    return level;
+    static std::atomic<LogLevel> storage{LogLevel::INFO};
+    return storage;
 }
 
 auto GetLogLevel() noexcept -> LogLevel
 {
-    return GetLogLevelRef();
+    return GetLogLevelStorage().load(std::memory_order_relaxed);
 }
 
 void SetLogLevel(LogLevel level) noexcept
 {
-    GetLogLevelRef() = level;
+    GetLogLevelStorage().store(level, std::memory_order_relaxed);
 }
 
 namespace


### PR DESCRIPTION
Replace the log level management with atomic storage to ensure thread safety when accessing and modifying the log level.