### PR TITLE
Add JSON support and improve calibration parameters

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/googletest"]
 	path = 3rdparty/googletest
 	url = https://github.com/google/googletest.git
+[submodule "3rdparty/json"]
+	path = 3rdparty/json
+	url = https://github.com/nlohmann/json.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,4 +1,5 @@
-# google test
+add_subdirectory(json)
+
 if(BUILD_TESTS)
     add_subdirectory(googletest)
 endif(BUILD_TESTS)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -8,9 +8,10 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-| Name            | Link                                            | License     | Copyright                          |
-| --------------- | ----------------------------------------------- | ----------- | ---------------------------------- |
-| Doxygen Awesome | https://github.com/jothepro/doxygen-awesome-css | MIT License | Copyright (c) 2021 - 2023 jothepro |
+| Name                | Link                                            | License     | Copyright                             |
+| ------------------- | ----------------------------------------------- | ----------- | ------------------------------------- |
+| Doxygen Awesome     | https://github.com/jothepro/doxygen-awesome-css | MIT License | Copyright (c) 2021-2023 jothepro      |
+| JSON for Modern C++ | https://github.com/nlohmann/json                | MIT License | Copyright (c) 2013-2025 Niels Lohmann |
 
 ## Apache-2.0
 

--- a/retinify/CMakeLists.txt
+++ b/retinify/CMakeLists.txt
@@ -39,6 +39,11 @@ target_compile_options(retinify
         $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
 )
 
+target_link_libraries(retinify
+    PRIVATE
+        nlohmann_json::nlohmann_json
+)
+
 if(BUILD_WITH_TENSORRT)
     add_subdirectory(src/cuda)
     target_link_libraries(retinify 

--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -308,31 +308,23 @@ struct CalibrationParameters
     std::uint32_t imageHeight{};
     /// @brief
     /// Root mean square reprojection error [pixels]
-    double reprojectionError{};
+    double calibrationError{};
     /// @brief
-    /// Calibration timestamp in Unix time [nanoseconds]
-    std::uint64_t calibrationTime{};
-    /// @brief
-    /// Left camera hardware serial
-    std::array<char, 128> leftCameraSerial{};
-    /// @brief
-    /// Right camera hardware serial
-    std::array<char, 128> rightCameraSerial{};
+    /// Calibration timestamp in UNIX time [seconds since epoch, UTC]
+    std::int64_t calibrationTime{};
 
     [[nodiscard]] auto operator==(const CalibrationParameters &other) const noexcept -> bool
     {
-        return leftIntrinsics == other.leftIntrinsics &&       //
-               leftDistortion == other.leftDistortion &&       //
-               rightIntrinsics == other.rightIntrinsics &&     //
-               rightDistortion == other.rightDistortion &&     //
-               rotation == other.rotation &&                   //
-               translation == other.translation &&             //
-               imageWidth == other.imageWidth &&               //
-               imageHeight == other.imageHeight &&             //
-               reprojectionError == other.reprojectionError && //
-               calibrationTime == other.calibrationTime &&     //
-               leftCameraSerial == other.leftCameraSerial &&   //
-               rightCameraSerial == other.rightCameraSerial;   //
+        return leftIntrinsics == other.leftIntrinsics &&     //
+               leftDistortion == other.leftDistortion &&     //
+               rightIntrinsics == other.rightIntrinsics &&   //
+               rightDistortion == other.rightDistortion &&   //
+               rotation == other.rotation &&                 //
+               translation == other.translation &&           //
+               imageWidth == other.imageWidth &&             //
+               imageHeight == other.imageHeight &&           //
+               calibrationError == other.calibrationError && //
+               calibrationTime == other.calibrationTime;     //
     }
 };
 

--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -284,22 +284,22 @@ struct CalibrationParameters
 {
     /// @brief
     /// Intrinsics for the left camera
-    Intrinsics leftIntrinsics;
+    Intrinsics leftIntrinsics{};
     /// @brief
     /// Distortion for the left camera
-    Distortion leftDistortion;
+    Distortion leftDistortion{};
     /// @brief
     /// Intrinsics for the right camera
-    Intrinsics rightIntrinsics;
+    Intrinsics rightIntrinsics{};
     /// @brief
     /// Distortion for the right camera
-    Distortion rightDistortion;
+    Distortion rightDistortion{};
     /// @brief
     /// Rotation from the left to the right camera
-    Mat3x3d rotation;
+    Mat3x3d rotation{};
     /// @brief
     /// Translation from the left to the right camera
-    Vec3d translation;
+    Vec3d translation{};
     /// @brief
     /// Image width [pixels]
     std::uint32_t imageWidth{};

--- a/retinify/src/io.cpp
+++ b/retinify/src/io.cpp
@@ -5,96 +5,52 @@
 #include "retinify/logging.hpp"
 
 #include <array>
-#include <bit>
 #include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <fstream>
-#include <string>
+
+#include <nlohmann/json.hpp>
 
 namespace retinify
 {
 namespace
 {
-constexpr std::uint32_t kFileMagicElementCount = 13;
-constexpr std::array<std::uint8_t, kFileMagicElementCount> kFileMagic{
-    static_cast<std::uint8_t>('R'), //
-    static_cast<std::uint8_t>('E'), //
-    static_cast<std::uint8_t>('T'), //
-    static_cast<std::uint8_t>('I'), //
-    static_cast<std::uint8_t>('N'), //
-    static_cast<std::uint8_t>('I'), //
-    static_cast<std::uint8_t>('F'), //
-    static_cast<std::uint8_t>('Y'), //
-    static_cast<std::uint8_t>('C'), //
-    static_cast<std::uint8_t>('A'), //
-    static_cast<std::uint8_t>('L'), //
-    static_cast<std::uint8_t>('I'), //
-    static_cast<std::uint8_t>('B'), //
-};
+constexpr int kJsonIndent = 2;
 
-constexpr std::uint32_t kFileFormatVersion = 1;
+constexpr const char kKeyLeftIntrinsics[] = "left_intrinsics";
+constexpr const char kKeyLeftDistortion[] = "left_distortion";
+constexpr const char kKeyRightIntrinsics[] = "right_intrinsics";
+constexpr const char kKeyRightDistortion[] = "right_distortion";
+constexpr const char kKeyRotation[] = "rotation";
+constexpr const char kKeyTranslation[] = "translation";
+constexpr const char kKeyImageWidth[] = "image_width";
+constexpr const char kKeyImageHeight[] = "image_height";
+constexpr const char kKeyCalibrationError[] = "calibration_error";
+constexpr const char kKeyLegacyReprojectionError[] = "reprojection_error";
+constexpr const char kKeyCalibrationTime[] = "calibration_time";
 
-constexpr std::size_t kIdxLeftFx = 0;
-constexpr std::size_t kIdxLeftFy = 1;
-constexpr std::size_t kIdxLeftCx = 2;
-constexpr std::size_t kIdxLeftCy = 3;
-constexpr std::size_t kIdxLeftSkew = 4;
+constexpr const char kKeyFx[] = "fx";
+constexpr const char kKeyFy[] = "fy";
+constexpr const char kKeyCx[] = "cx";
+constexpr const char kKeyCy[] = "cy";
+constexpr const char kKeySkew[] = "skew";
 
-constexpr std::size_t kIdxLeftK1 = 5;
-constexpr std::size_t kIdxLeftK2 = 6;
-constexpr std::size_t kIdxLeftP1 = 7;
-constexpr std::size_t kIdxLeftP2 = 8;
-constexpr std::size_t kIdxLeftK3 = 9;
-constexpr std::size_t kIdxLeftK4 = 10;
-constexpr std::size_t kIdxLeftK5 = 11;
-constexpr std::size_t kIdxLeftK6 = 12;
+constexpr const char kKeyK1[] = "k1";
+constexpr const char kKeyK2[] = "k2";
+constexpr const char kKeyP1[] = "p1";
+constexpr const char kKeyP2[] = "p2";
+constexpr const char kKeyK3[] = "k3";
+constexpr const char kKeyK4[] = "k4";
+constexpr const char kKeyK5[] = "k5";
+constexpr const char kKeyK6[] = "k6";
 
-constexpr std::size_t kIdxRightFx = 13;
-constexpr std::size_t kIdxRightFy = 14;
-constexpr std::size_t kIdxRightCx = 15;
-constexpr std::size_t kIdxRightCy = 16;
-constexpr std::size_t kIdxRightSkew = 17;
+[[nodiscard]] auto IsFilenameEmpty(const char *filename) noexcept -> bool
+{
+    return filename == nullptr || filename[0] == '\0';
+}
 
-constexpr std::size_t kIdxRightK1 = 18;
-constexpr std::size_t kIdxRightK2 = 19;
-constexpr std::size_t kIdxRightP1 = 20;
-constexpr std::size_t kIdxRightP2 = 21;
-constexpr std::size_t kIdxRightK3 = 22;
-constexpr std::size_t kIdxRightK4 = 23;
-constexpr std::size_t kIdxRightK5 = 24;
-constexpr std::size_t kIdxRightK6 = 25;
-
-constexpr std::size_t kIdxRotation00 = 26;
-constexpr std::size_t kIdxRotation01 = 27;
-constexpr std::size_t kIdxRotation02 = 28;
-constexpr std::size_t kIdxRotation10 = 29;
-constexpr std::size_t kIdxRotation11 = 30;
-constexpr std::size_t kIdxRotation12 = 31;
-constexpr std::size_t kIdxRotation20 = 32;
-constexpr std::size_t kIdxRotation21 = 33;
-constexpr std::size_t kIdxRotation22 = 34;
-
-constexpr std::size_t kIdxTranslationX = 35;
-constexpr std::size_t kIdxTranslationY = 36;
-constexpr std::size_t kIdxTranslationZ = 37;
-
-constexpr std::size_t kStereoCameraParametersElementCount = 38;
-
-constexpr std::size_t kCameraSerialSize = 128;
-
-constexpr std::uintmax_t kExpectedFileSize = (kFileMagicElementCount * sizeof(std::uint8_t)) +        // file magic
-                                             sizeof(std::uint32_t) +                                  // file format version
-                                             (kStereoCameraParametersElementCount * sizeof(double)) + // stereo camera parameters
-                                             (2 * sizeof(std::uint32_t)) +                            // imageWidth, imageHeight
-                                             sizeof(double) +                                         // reprojectionError
-                                             sizeof(std::uint64_t) +                                  // calibrationTime
-                                             (2 * kCameraSerialSize * sizeof(char));                  // left & right serial
-
-constexpr bool kIsNativeLittleEndian = (std::endian::native == std::endian::little);
-
-// Create parent directories if needed
-[[nodiscard]] auto CreateParentDirectories(const std::filesystem::path &filePath) -> Status
+[[nodiscard]] auto EnsureParentDirectory(const std::filesystem::path &filePath) -> Status
 {
     const auto parent = filePath.parent_path();
     if (parent.empty())
@@ -112,556 +68,281 @@ constexpr bool kIsNativeLittleEndian = (std::endian::native == std::endian::litt
     return Status();
 }
 
-// Compose a unique temporary path candidate next to the target file.
-[[nodiscard]] auto ComposeTemporaryCandidate(const std::filesystem::path &parent, std::string baseName, int attempt) -> std::filesystem::path
+template <typename T, typename Validator> [[nodiscard]] auto ReadValue(const nlohmann::json &obj, const char *key, Validator validator, T &out) -> bool
 {
-    if (baseName.empty())
-    {
-        baseName = "retinify-calibration";
-    }
-
-    std::string candidate = baseName + ".tmp";
-    if (attempt > 0)
-    {
-        candidate += '-' + std::to_string(attempt);
-    }
-
-    return parent.empty() ? std::filesystem::path(candidate) : parent / candidate;
-}
-
-// Find an unused temporary path for the target file.
-[[nodiscard]] auto MakeTemporaryPath(const std::filesystem::path &targetPath, std::error_code &ec) -> std::filesystem::path
-{
-    const auto parent = targetPath.parent_path();
-    std::string baseName = targetPath.filename().string();
-
-    constexpr int kMaxTemporaryPathAttempts = 64;
-    for (int attempt = 0; attempt < kMaxTemporaryPathAttempts; ++attempt)
-    {
-        const auto candidate = ComposeTemporaryCandidate(parent, baseName, attempt);
-
-        std::error_code existsError;
-        const bool exists = std::filesystem::exists(candidate, existsError);
-        if (existsError)
-        {
-            ec = existsError;
-            return {};
-        }
-
-        if (!exists)
-        {
-            ec.clear();
-            return candidate;
-        }
-    }
-
-    ec = std::make_error_code(std::errc::file_exists);
-    return {};
-}
-
-// Delete the provided path when present, ignoring errors.
-auto RemovePathIfExists(const std::filesystem::path &path) noexcept -> void
-{
-    if (path.empty())
-    {
-        return;
-    }
-
-    std::error_code ec;
-    std::filesystem::remove(path, ec);
-}
-
-[[nodiscard]] constexpr auto Byteswap32(std::uint32_t value) noexcept -> std::uint32_t
-{
-    return ((value & 0x000000FFu) << 24) | //
-           ((value & 0x0000FF00u) << 8) |  //
-           ((value & 0x00FF0000u) >> 8) |  //
-           ((value & 0xFF000000u) >> 24);
-}
-
-[[nodiscard]] constexpr auto Byteswap64(std::uint64_t value) noexcept -> std::uint64_t
-{
-    return ((value & 0x00000000000000FFull) << 56) | //
-           ((value & 0x000000000000FF00ull) << 40) | //
-           ((value & 0x0000000000FF0000ull) << 24) | //
-           ((value & 0x00000000FF000000ull) << 8) |  //
-           ((value & 0x000000FF00000000ull) >> 8) |  //
-           ((value & 0x0000FF0000000000ull) >> 24) | //
-           ((value & 0x00FF000000000000ull) >> 40) | //
-           ((value & 0xFF00000000000000ull) >> 56);
-}
-
-[[nodiscard]] auto WriteUint32(std::ostream &stream, std::uint32_t value) -> bool
-{
-    auto temp = value;
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        temp = Byteswap32(temp);
-    }
-
-    stream.write(reinterpret_cast<const char *>(&temp), sizeof(temp));
-    return stream.good();
-}
-
-[[nodiscard]] auto WriteUint64(std::ostream &stream, std::uint64_t value) -> bool
-{
-    auto temp = value;
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        temp = Byteswap64(temp);
-    }
-
-    stream.write(reinterpret_cast<const char *>(&temp), sizeof(temp));
-    return stream.good();
-}
-
-[[nodiscard]] auto WriteDouble(std::ostream &stream, double value) -> bool
-{
-    auto bits = std::bit_cast<std::uint64_t>(value);
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        bits = Byteswap64(bits);
-    }
-
-    stream.write(reinterpret_cast<const char *>(&bits), sizeof(bits));
-    return stream.good();
-}
-
-[[nodiscard]] auto ReadUint32(std::istream &stream, std::uint32_t &value) -> bool
-{
-    std::uint32_t temp{};
-    stream.read(reinterpret_cast<char *>(&temp), sizeof(temp));
-
-    if (!stream)
+    const auto it = obj.find(key);
+    if (it == obj.end() || !validator(*it))
     {
         return false;
     }
 
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        temp = Byteswap32(temp);
-    }
-
-    value = temp;
+    out = it->get<T>();
     return true;
 }
 
-[[nodiscard]] auto ReadUint64(std::istream &stream, std::uint64_t &value) -> bool
+template <typename T> [[nodiscard]] auto ReadNumber(const nlohmann::json &obj, const char *key, T &out) -> bool
 {
-    std::uint64_t temp{};
-    stream.read(reinterpret_cast<char *>(&temp), sizeof(temp));
+    return ReadValue(obj, key, [](const nlohmann::json &value) { return value.is_number(); }, out);
+}
 
-    if (!stream)
+template <typename T> [[nodiscard]] auto ReadIntegral(const nlohmann::json &obj, const char *key, T &out) -> bool
+{
+    return ReadValue(obj, key, [](const nlohmann::json &value) { return value.is_number_integer() || value.is_number_unsigned(); }, out);
+}
+
+[[nodiscard]] auto SerializeIntrinsics(const Intrinsics &intrinsics) -> nlohmann::json
+{
+    return {{kKeyFx, intrinsics.fx}, //
+            {kKeyFy, intrinsics.fy}, //
+            {kKeyCx, intrinsics.cx}, //
+            {kKeyCy, intrinsics.cy}, //
+            {kKeySkew, intrinsics.skew}};
+}
+
+[[nodiscard]] auto SerializeDistortion(const Distortion &distortion) -> nlohmann::json
+{
+    return {{kKeyK1, distortion.k1}, //
+            {kKeyK2, distortion.k2}, //
+            {kKeyP1, distortion.p1}, //
+            {kKeyP2, distortion.p2}, //
+            {kKeyK3, distortion.k3}, //
+            {kKeyK4, distortion.k4}, //
+            {kKeyK5, distortion.k5}, //
+            {kKeyK6, distortion.k6}};
+}
+
+[[nodiscard]] auto SerializeCalibration(const CalibrationParameters &parameters) -> nlohmann::json
+{
+    return {{kKeyLeftIntrinsics, SerializeIntrinsics(parameters.leftIntrinsics)},   //
+            {kKeyLeftDistortion, SerializeDistortion(parameters.leftDistortion)},   //
+            {kKeyRightIntrinsics, SerializeIntrinsics(parameters.rightIntrinsics)}, //
+            {kKeyRightDistortion, SerializeDistortion(parameters.rightDistortion)}, //
+            {kKeyRotation, parameters.rotation},                                    //
+            {kKeyTranslation, parameters.translation},                              //
+            {kKeyImageWidth, parameters.imageWidth},                                //
+            {kKeyImageHeight, parameters.imageHeight},                              //
+            {kKeyCalibrationError, parameters.calibrationError},                    //
+            {kKeyCalibrationTime, parameters.calibrationTime}};
+}
+
+[[nodiscard]] auto DeserializeIntrinsics(const nlohmann::json &value, Intrinsics &intrinsics) -> bool
+{
+    if (!value.is_object())
     {
         return false;
     }
 
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        temp = Byteswap64(temp);
-    }
-
-    value = temp;
-    return true;
+    return ReadNumber(value, kKeyFx, intrinsics.fx) && //
+           ReadNumber(value, kKeyFy, intrinsics.fy) && //
+           ReadNumber(value, kKeyCx, intrinsics.cx) && //
+           ReadNumber(value, kKeyCy, intrinsics.cy) && //
+           ReadNumber(value, kKeySkew, intrinsics.skew);
 }
 
-[[nodiscard]] auto ReadDouble(std::istream &stream, double &value) -> bool
+[[nodiscard]] auto DeserializeDistortion(const nlohmann::json &value, Distortion &distortion) -> bool
 {
-    std::uint64_t bits{};
-    stream.read(reinterpret_cast<char *>(&bits), sizeof(bits));
-
-    if (!stream)
+    if (!value.is_object())
     {
         return false;
     }
 
-    if constexpr (!kIsNativeLittleEndian)
-    {
-        bits = Byteswap64(bits);
-    }
-
-    value = std::bit_cast<double>(bits);
-    return true;
+    return ReadNumber(value, kKeyK1, distortion.k1) && //
+           ReadNumber(value, kKeyK2, distortion.k2) && //
+           ReadNumber(value, kKeyP1, distortion.p1) && //
+           ReadNumber(value, kKeyP2, distortion.p2) && //
+           ReadNumber(value, kKeyK3, distortion.k3) && //
+           ReadNumber(value, kKeyK4, distortion.k4) && //
+           ReadNumber(value, kKeyK5, distortion.k5) && //
+           ReadNumber(value, kKeyK6, distortion.k6);
 }
 
-template <std::size_t N> [[nodiscard]] auto WriteDoubleArray(std::ostream &stream, const std::array<double, N> &values) -> bool
+template <std::size_t N> [[nodiscard]] auto DeserializeVector(const nlohmann::json &value, std::array<double, N> &out) -> bool
 {
-    for (const double value : values)
+    if (!value.is_array() || value.size() != N)
     {
-        if (!WriteDouble(stream, value))
+        return false;
+    }
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        if (!value[i].is_number())
         {
             return false;
         }
+        out[i] = value[i].get<double>();
     }
 
     return true;
 }
 
-template <std::size_t N> [[nodiscard]] auto ReadDoubleArray(std::istream &stream, std::array<double, N> &values) -> bool
+template <std::size_t Rows, std::size_t Cols> [[nodiscard]] auto DeserializeMatrix(const nlohmann::json &value, std::array<std::array<double, Cols>, Rows> &out) -> bool
 {
-    for (auto &value : values)
+    if (!value.is_array() || value.size() != Rows)
     {
-        if (!ReadDouble(stream, value))
+        return false;
+    }
+
+    for (std::size_t r = 0; r < Rows; ++r)
+    {
+        const auto &row = value[r];
+        if (!row.is_array() || row.size() != Cols)
         {
             return false;
+        }
+
+        for (std::size_t c = 0; c < Cols; ++c)
+        {
+            if (!row[c].is_number())
+            {
+                return false;
+            }
+            out[r][c] = row[c].get<double>();
         }
     }
 
     return true;
 }
 
-template <std::size_t N> [[nodiscard]] auto WriteCharArray(std::ostream &stream, const std::array<char, N> &buffer) -> bool
+[[nodiscard]] auto DeserializeCalibration(const nlohmann::json &doc, CalibrationParameters &parameters) -> bool
 {
-    stream.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-    return stream.good();
-}
-
-template <std::size_t N> [[nodiscard]] auto ReadCharArray(std::istream &stream, std::array<char, N> &buffer) -> bool
-{
-    stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-    if (!stream)
-    {
-        return false;
-    }
-    return true;
-}
-
-[[nodiscard]] auto FlattenStereoCameraParameters(const CalibrationParameters &parameters) noexcept -> std::array<double, kStereoCameraParametersElementCount>
-{
-    std::array<double, kStereoCameraParametersElementCount> values{};
-    values[kIdxLeftFx] = parameters.leftIntrinsics.fx;
-    values[kIdxLeftFy] = parameters.leftIntrinsics.fy;
-    values[kIdxLeftCx] = parameters.leftIntrinsics.cx;
-    values[kIdxLeftCy] = parameters.leftIntrinsics.cy;
-    values[kIdxLeftSkew] = parameters.leftIntrinsics.skew;
-
-    values[kIdxLeftK1] = parameters.leftDistortion.k1;
-    values[kIdxLeftK2] = parameters.leftDistortion.k2;
-    values[kIdxLeftP1] = parameters.leftDistortion.p1;
-    values[kIdxLeftP2] = parameters.leftDistortion.p2;
-    values[kIdxLeftK3] = parameters.leftDistortion.k3;
-    values[kIdxLeftK4] = parameters.leftDistortion.k4;
-    values[kIdxLeftK5] = parameters.leftDistortion.k5;
-    values[kIdxLeftK6] = parameters.leftDistortion.k6;
-
-    values[kIdxRightFx] = parameters.rightIntrinsics.fx;
-    values[kIdxRightFy] = parameters.rightIntrinsics.fy;
-    values[kIdxRightCx] = parameters.rightIntrinsics.cx;
-    values[kIdxRightCy] = parameters.rightIntrinsics.cy;
-    values[kIdxRightSkew] = parameters.rightIntrinsics.skew;
-
-    values[kIdxRightK1] = parameters.rightDistortion.k1;
-    values[kIdxRightK2] = parameters.rightDistortion.k2;
-    values[kIdxRightP1] = parameters.rightDistortion.p1;
-    values[kIdxRightP2] = parameters.rightDistortion.p2;
-    values[kIdxRightK3] = parameters.rightDistortion.k3;
-    values[kIdxRightK4] = parameters.rightDistortion.k4;
-    values[kIdxRightK5] = parameters.rightDistortion.k5;
-    values[kIdxRightK6] = parameters.rightDistortion.k6;
-
-    values[kIdxRotation00] = parameters.rotation[0][0];
-    values[kIdxRotation01] = parameters.rotation[0][1];
-    values[kIdxRotation02] = parameters.rotation[0][2];
-    values[kIdxRotation10] = parameters.rotation[1][0];
-    values[kIdxRotation11] = parameters.rotation[1][1];
-    values[kIdxRotation12] = parameters.rotation[1][2];
-    values[kIdxRotation20] = parameters.rotation[2][0];
-    values[kIdxRotation21] = parameters.rotation[2][1];
-    values[kIdxRotation22] = parameters.rotation[2][2];
-
-    values[kIdxTranslationX] = parameters.translation[0];
-    values[kIdxTranslationY] = parameters.translation[1];
-    values[kIdxTranslationZ] = parameters.translation[2];
-
-    return values;
-}
-
-auto PopulateStereoCameraParameters(const std::array<double, kStereoCameraParametersElementCount> &values, CalibrationParameters &parameters) noexcept -> void
-{
-    parameters.leftIntrinsics.fx = values[kIdxLeftFx];
-    parameters.leftIntrinsics.fy = values[kIdxLeftFy];
-    parameters.leftIntrinsics.cx = values[kIdxLeftCx];
-    parameters.leftIntrinsics.cy = values[kIdxLeftCy];
-    parameters.leftIntrinsics.skew = values[kIdxLeftSkew];
-
-    parameters.leftDistortion.k1 = values[kIdxLeftK1];
-    parameters.leftDistortion.k2 = values[kIdxLeftK2];
-    parameters.leftDistortion.p1 = values[kIdxLeftP1];
-    parameters.leftDistortion.p2 = values[kIdxLeftP2];
-    parameters.leftDistortion.k3 = values[kIdxLeftK3];
-    parameters.leftDistortion.k4 = values[kIdxLeftK4];
-    parameters.leftDistortion.k5 = values[kIdxLeftK5];
-    parameters.leftDistortion.k6 = values[kIdxLeftK6];
-
-    parameters.rightIntrinsics.fx = values[kIdxRightFx];
-    parameters.rightIntrinsics.fy = values[kIdxRightFy];
-    parameters.rightIntrinsics.cx = values[kIdxRightCx];
-    parameters.rightIntrinsics.cy = values[kIdxRightCy];
-    parameters.rightIntrinsics.skew = values[kIdxRightSkew];
-
-    parameters.rightDistortion.k1 = values[kIdxRightK1];
-    parameters.rightDistortion.k2 = values[kIdxRightK2];
-    parameters.rightDistortion.p1 = values[kIdxRightP1];
-    parameters.rightDistortion.p2 = values[kIdxRightP2];
-    parameters.rightDistortion.k3 = values[kIdxRightK3];
-    parameters.rightDistortion.k4 = values[kIdxRightK4];
-    parameters.rightDistortion.k5 = values[kIdxRightK5];
-    parameters.rightDistortion.k6 = values[kIdxRightK6];
-
-    parameters.rotation[0][0] = values[kIdxRotation00];
-    parameters.rotation[0][1] = values[kIdxRotation01];
-    parameters.rotation[0][2] = values[kIdxRotation02];
-    parameters.rotation[1][0] = values[kIdxRotation10];
-    parameters.rotation[1][1] = values[kIdxRotation11];
-    parameters.rotation[1][2] = values[kIdxRotation12];
-    parameters.rotation[2][0] = values[kIdxRotation20];
-    parameters.rotation[2][1] = values[kIdxRotation21];
-    parameters.rotation[2][2] = values[kIdxRotation22];
-
-    parameters.translation[0] = values[kIdxTranslationX];
-    parameters.translation[1] = values[kIdxTranslationY];
-    parameters.translation[2] = values[kIdxTranslationZ];
-}
-
-// Write calibration data to stream
-[[nodiscard]] auto WriteCalibrationData(std::ostream &stream, const CalibrationParameters &parameters) -> bool
-{
-    stream.write(reinterpret_cast<const char *>(kFileMagic.data()), static_cast<std::streamsize>(kFileMagic.size()));
-    if (!stream.good())
+    if (!doc.is_object())
     {
         return false;
     }
 
-    if (!WriteUint32(stream, kFileFormatVersion))
+    CalibrationParameters parsed{};
+
+    const auto leftIntrinsicsIt = doc.find(kKeyLeftIntrinsics);
+    if (leftIntrinsicsIt == doc.end() || !DeserializeIntrinsics(*leftIntrinsicsIt, parsed.leftIntrinsics))
     {
         return false;
     }
 
-    const auto payload = FlattenStereoCameraParameters(parameters);
-    if (!WriteDoubleArray(stream, payload))
+    const auto rightIntrinsicsIt = doc.find(kKeyRightIntrinsics);
+    if (rightIntrinsicsIt == doc.end() || !DeserializeIntrinsics(*rightIntrinsicsIt, parsed.rightIntrinsics))
     {
         return false;
     }
 
-    if (!WriteUint32(stream, parameters.imageWidth))
-    {
-        return false;
-    }
-    if (!WriteUint32(stream, parameters.imageHeight))
-    {
-        return false;
-    }
-
-    if (!WriteDouble(stream, parameters.reprojectionError))
+    const auto leftDistortionIt = doc.find(kKeyLeftDistortion);
+    if (leftDistortionIt == doc.end() || !DeserializeDistortion(*leftDistortionIt, parsed.leftDistortion))
     {
         return false;
     }
 
-    if (!WriteUint64(stream, parameters.calibrationTime))
+    const auto rightDistortionIt = doc.find(kKeyRightDistortion);
+    if (rightDistortionIt == doc.end() || !DeserializeDistortion(*rightDistortionIt, parsed.rightDistortion))
     {
         return false;
     }
 
-    if (!WriteCharArray(stream, parameters.leftCameraSerial))
+    const auto rotationIt = doc.find(kKeyRotation);
+    if (rotationIt == doc.end() || !DeserializeMatrix(*rotationIt, parsed.rotation))
     {
         return false;
     }
 
-    if (!WriteCharArray(stream, parameters.rightCameraSerial))
+    const auto translationIt = doc.find(kKeyTranslation);
+    if (translationIt == doc.end() || !DeserializeVector(*translationIt, parsed.translation))
     {
         return false;
     }
 
-    return true;
-}
-
-// Cleanup temporary file on failure
-[[nodiscard]] auto CleanupAndFail(const std::filesystem::path &tempPath) noexcept -> Status
-{
-    RemovePathIfExists(tempPath);
-    return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
-}
-
-// Determine if any bytes remain unread in the stream.
-[[nodiscard]] auto HasTrailingContent(std::istream &stream) -> bool
-{
-    const auto next = stream.peek();
-    if (next == std::char_traits<char>::eof())
-    {
-        stream.clear(stream.rdstate() & ~std::ios::failbit);
-        return false;
-    }
-
-    return true;
-}
-
-// Read and validate calibration data from stream
-[[nodiscard]] auto ReadCalibrationData(std::istream &stream, CalibrationParameters &parameters) -> bool
-{
-    std::array<std::uint8_t, kFileMagicElementCount> magic{};
-    stream.read(reinterpret_cast<char *>(magic.data()), static_cast<std::streamsize>(magic.size()));
-    if (!stream || magic != kFileMagic)
+    if (!ReadIntegral(doc, kKeyImageWidth, parsed.imageWidth))
     {
         return false;
     }
 
-    std::uint32_t version{};
-    if (!ReadUint32(stream, version) || version != kFileFormatVersion)
+    if (!ReadIntegral(doc, kKeyImageHeight, parsed.imageHeight))
     {
         return false;
     }
 
-    std::array<double, kStereoCameraParametersElementCount> payload{};
-    if (!ReadDoubleArray(stream, payload))
+    if (!ReadNumber(doc, kKeyCalibrationError, parsed.calibrationError) && !ReadNumber(doc, kKeyLegacyReprojectionError, parsed.calibrationError))
     {
         return false;
     }
 
-    std::uint32_t imageWidth{};
-    if (!ReadUint32(stream, imageWidth))
-    {
-        return false;
-    }
-    std::uint32_t imageHeight{};
-    if (!ReadUint32(stream, imageHeight))
+    if (!ReadIntegral(doc, kKeyCalibrationTime, parsed.calibrationTime))
     {
         return false;
     }
 
-    double rms{};
-    if (!ReadDouble(stream, rms))
-    {
-        return false;
-    }
-    std::uint64_t calibrationTime{};
-    if (!ReadUint64(stream, calibrationTime))
-    {
-        return false;
-    }
-
-    std::array<char, kCameraSerialSize> leftSerial{};
-    if (!ReadCharArray(stream, leftSerial))
-    {
-        return false;
-    }
-
-    std::array<char, kCameraSerialSize> rightSerial{};
-    if (!ReadCharArray(stream, rightSerial))
-    {
-        return false;
-    }
-
-    if (HasTrailingContent(stream))
-    {
-        return false;
-    }
-
-    PopulateStereoCameraParameters(payload, parameters);
-    parameters.reprojectionError = rms;
-    parameters.calibrationTime = calibrationTime;
-    parameters.leftCameraSerial = leftSerial;
-    parameters.rightCameraSerial = rightSerial;
-    parameters.imageWidth = imageWidth;
-    parameters.imageHeight = imageHeight;
-
+    parameters = parsed;
     return true;
 }
 } // namespace
 
 auto SaveCalibrationParameters(const char *filename, const CalibrationParameters &parameters) noexcept -> Status
 {
-    if (filename == nullptr || filename[0] == '\0')
+    if (IsFilenameEmpty(filename))
     {
         return Status(StatusCategory::USER, StatusCode::INVALID_ARGUMENT);
     }
-
-    std::filesystem::path tempPath;
 
     try
     {
         const std::filesystem::path targetPath(filename);
 
-        const auto dirStatus = CreateParentDirectories(targetPath);
+        const auto dirStatus = EnsureParentDirectory(targetPath);
         if (!dirStatus.IsOK())
         {
             return dirStatus;
         }
 
-        std::error_code fsError;
-        tempPath = MakeTemporaryPath(targetPath, fsError);
-        if (fsError || tempPath.empty())
+        std::ofstream out(targetPath, std::ios::trunc);
+        if (!out.is_open())
         {
             return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
         }
 
-        std::ofstream out(tempPath, std::ios::out | std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
+        const auto json = SerializeCalibration(parameters);
+        out << json.dump(kJsonIndent) << '\n';
+
+        out.flush();
+        if (!out.good())
         {
-            return CleanupAndFail(tempPath);
+            return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
         }
 
-        if (!WriteCalibrationData(out, parameters))
-        {
-            return CleanupAndFail(tempPath);
-        }
-
-        out.close();
-        if (out.fail())
-        {
-            return CleanupAndFail(tempPath);
-        }
-
-        fsError.clear();
-        std::filesystem::rename(tempPath, targetPath, fsError);
-        if (fsError)
-        {
-            return CleanupAndFail(tempPath);
-        }
         return Status();
     }
     catch (const std::exception &e)
     {
         LogError(e.what());
-        RemovePathIfExists(tempPath);
         return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
     }
     catch (...)
     {
-        RemovePathIfExists(tempPath);
         return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
     }
 }
 
 auto LoadCalibrationParameters(const char *filename, CalibrationParameters &parameters) noexcept -> Status
 {
-    if (filename == nullptr || filename[0] == '\0')
+    if (IsFilenameEmpty(filename))
     {
         return Status(StatusCategory::USER, StatusCode::INVALID_ARGUMENT);
     }
 
     try
     {
-        const std::filesystem::path path(filename);
-        std::error_code sizeError;
-        const auto fileSize = std::filesystem::file_size(path, sizeError);
-        if (sizeError || fileSize != kExpectedFileSize)
-        {
-            return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
-        }
-
-        std::ifstream in(filename, std::ios::in | std::ios::binary);
+        std::ifstream in(filename, std::ios::in);
         if (!in.is_open())
         {
             return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
         }
 
-        CalibrationParameters parsed{};
-        if (!ReadCalibrationData(in, parsed))
+        const auto doc = nlohmann::json::parse(in, nullptr, false);
+        if (doc.is_discarded())
         {
             return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
         }
 
-        parameters = parsed;
+        if (!DeserializeCalibration(doc, parameters))
+        {
+            return Status(StatusCategory::SYSTEM, StatusCode::FAIL);
+        }
 
         return Status();
     }

--- a/retinify/tests/CMakeLists.txt
+++ b/retinify/tests/CMakeLists.txt
@@ -9,7 +9,10 @@ add_executable(retinify-tests ${SRCS_TESTS} ${SRC_RETINIFY})
 
 # LINKS
 target_link_libraries(retinify-tests 
-    PUBLIC retinify ${OpenCV_LIBS} gtest gtest_main
+    PUBLIC
+        retinify ${OpenCV_LIBS} gtest gtest_main
+    PRIVATE
+        nlohmann_json::nlohmann_json
 )
 
 # BUILD OPTIONS

--- a/retinify/tests/io_test.cpp
+++ b/retinify/tests/io_test.cpp
@@ -3,12 +3,10 @@
 
 #include "retinify/io.hpp"
 
-#include <algorithm>
-#include <bit>
+#include <array>
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
-#include <iostream>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -101,110 +99,65 @@ class ScopedTempDir
 
     params.imageWidth = 640;
     params.imageHeight = 480;
-    params.reprojectionError = 0.25;
-    params.calibrationTime = 1720000000123456789ull;
-    const char left[] = "LEFT1234567890";
-    const char right[] = "RIGHT0987654321";
-    std::copy(std::begin(left), std::end(left), params.leftCameraSerial.begin());
-    std::copy(std::begin(right), std::end(right), params.rightCameraSerial.begin());
+    params.calibrationError = 0.25;
+    params.calibrationTime = 1720000000123456789ll;
 
     return params;
 }
 
-auto ExpectIntrinsicsEqual(const Intrinsics &expected, const Intrinsics &actual) -> void
+class IoTest : public ::testing::Test
 {
-    EXPECT_DOUBLE_EQ(expected.fx, actual.fx);
-    EXPECT_DOUBLE_EQ(expected.fy, actual.fy);
-    EXPECT_DOUBLE_EQ(expected.cx, actual.cx);
-    EXPECT_DOUBLE_EQ(expected.cy, actual.cy);
-    EXPECT_DOUBLE_EQ(expected.skew, actual.skew);
-}
-
-auto ExpectDistortionEqual(const Distortion &expected, const Distortion &actual) -> void
-{
-    EXPECT_DOUBLE_EQ(expected.k1, actual.k1);
-    EXPECT_DOUBLE_EQ(expected.k2, actual.k2);
-    EXPECT_DOUBLE_EQ(expected.p1, actual.p1);
-    EXPECT_DOUBLE_EQ(expected.p2, actual.p2);
-    EXPECT_DOUBLE_EQ(expected.k3, actual.k3);
-    EXPECT_DOUBLE_EQ(expected.k4, actual.k4);
-    EXPECT_DOUBLE_EQ(expected.k5, actual.k5);
-    EXPECT_DOUBLE_EQ(expected.k6, actual.k6);
-}
-
-auto ExpectRotationEqual(const Mat3x3d &expected, const Mat3x3d &actual) -> void
-{
-    for (std::size_t row = 0; row < expected.size(); ++row)
+  protected:
+    [[nodiscard]] auto Path(const std::string &filename) const -> std::filesystem::path
     {
-        for (std::size_t col = 0; col < expected[row].size(); ++col)
-        {
-            EXPECT_DOUBLE_EQ(expected[row][col], actual[row][col]) << "rotation mismatch at (" << row << ", " << col << ")";
-        }
+        return tempDir_.path() / filename;
     }
-}
 
-auto ExpectTranslationEqual(const Vec3d &expected, const Vec3d &actual) -> void
-{
-    for (std::size_t idx = 0; idx < expected.size(); ++idx)
+    [[nodiscard]] auto Save(const std::filesystem::path &path, const CalibrationParameters &params) const -> Status
     {
-        EXPECT_DOUBLE_EQ(expected[idx], actual[idx]) << "translation mismatch at index " << idx;
+        const auto pathString = path.string();
+        return SaveCalibrationParameters(pathString.c_str(), params);
     }
-}
 
-auto ExpectParametersEqual(const CalibrationParameters &expected, const CalibrationParameters &actual) -> void
-{
-    ExpectIntrinsicsEqual(expected.leftIntrinsics, actual.leftIntrinsics);
-    ExpectDistortionEqual(expected.leftDistortion, actual.leftDistortion);
-    ExpectIntrinsicsEqual(expected.rightIntrinsics, actual.rightIntrinsics);
-    ExpectDistortionEqual(expected.rightDistortion, actual.rightDistortion);
-    ExpectRotationEqual(expected.rotation, actual.rotation);
-    ExpectTranslationEqual(expected.translation, actual.translation);
-    EXPECT_EQ(expected.imageWidth, actual.imageWidth);
-    EXPECT_EQ(expected.imageHeight, actual.imageHeight);
-    EXPECT_DOUBLE_EQ(expected.reprojectionError, actual.reprojectionError);
-    EXPECT_EQ(expected.calibrationTime, actual.calibrationTime);
-    EXPECT_EQ(std::string(expected.leftCameraSerial.data(), expected.leftCameraSerial.size()), std::string(actual.leftCameraSerial.data(), actual.leftCameraSerial.size()));
-    EXPECT_EQ(std::string(expected.rightCameraSerial.data(), expected.rightCameraSerial.size()), std::string(actual.rightCameraSerial.data(), actual.rightCameraSerial.size()));
-}
+    [[nodiscard]] auto Load(const std::filesystem::path &path, CalibrationParameters &params) const -> Status
+    {
+        const auto pathString = path.string();
+        return LoadCalibrationParameters(pathString.c_str(), params);
+    }
 
-auto Byteswap32(std::uint32_t value) -> std::uint32_t
-{
-    return ((value & 0x000000FFu) << 24) | ((value & 0x0000FF00u) << 8) | ((value & 0x00FF0000u) >> 8) | ((value & 0xFF000000u) >> 24);
-}
+    ScopedTempDir tempDir_;
+    CalibrationParameters sample_{MakeSampleParameters()};
+};
 } // namespace
 
-TEST(IoTest, SaveAndLoadRoundTrip)
+TEST_F(IoTest, SaveAndLoadRoundTrip)
 {
-    ScopedTempDir tempDir;
-    const auto filePath = tempDir.path() / "calibration.bin";
-    const auto params = MakeSampleParameters();
+    const auto filePath = Path("calibration.json");
 
-    const auto saveStatus = SaveCalibrationParameters(filePath.string().c_str(), params);
+    const auto saveStatus = Save(filePath, sample_);
     ASSERT_TRUE(saveStatus.IsOK());
 
     CalibrationParameters loaded{};
-    const auto loadStatus = LoadCalibrationParameters(filePath.string().c_str(), loaded);
+    const auto loadStatus = Load(filePath, loaded);
     ASSERT_TRUE(loadStatus.IsOK());
 
-    ExpectParametersEqual(params, loaded);
+    EXPECT_EQ(sample_, loaded);
 }
 
-TEST(IoTest, SaveRejectsInvalidFilename)
+TEST_F(IoTest, SaveRejectsInvalidFilename)
 {
-    const auto params = MakeSampleParameters();
-
-    const auto nullStatus = SaveCalibrationParameters(nullptr, params);
+    const auto nullStatus = SaveCalibrationParameters(nullptr, sample_);
     EXPECT_FALSE(nullStatus.IsOK());
     EXPECT_EQ(nullStatus.Category(), StatusCategory::USER);
     EXPECT_EQ(nullStatus.Code(), StatusCode::INVALID_ARGUMENT);
 
-    const auto emptyStatus = SaveCalibrationParameters("", params);
+    const auto emptyStatus = SaveCalibrationParameters("", sample_);
     EXPECT_FALSE(emptyStatus.IsOK());
     EXPECT_EQ(emptyStatus.Category(), StatusCategory::USER);
     EXPECT_EQ(emptyStatus.Code(), StatusCode::INVALID_ARGUMENT);
 }
 
-TEST(IoTest, LoadRejectsInvalidFilename)
+TEST_F(IoTest, LoadRejectsInvalidFilename)
 {
     CalibrationParameters params{};
 
@@ -219,19 +172,17 @@ TEST(IoTest, LoadRejectsInvalidFilename)
     EXPECT_EQ(emptyStatus.Code(), StatusCode::INVALID_ARGUMENT);
 }
 
-TEST(IoTest, SaveFailsWhenParentIsFile)
+TEST_F(IoTest, SaveFailsWhenParentIsFile)
 {
-    ScopedTempDir tempDir;
-    const auto parent = tempDir.path() / "not-a-directory";
+    const auto parent = Path("not-a-directory");
     {
         std::ofstream marker(parent);
         ASSERT_TRUE(marker.is_open());
     }
 
-    const auto target = parent / "calibration.bin";
-    const auto params = MakeSampleParameters();
+    const auto target = parent / "calibration.json";
 
-    const auto status = SaveCalibrationParameters(target.string().c_str(), params);
+    const auto status = Save(target, sample_);
     EXPECT_FALSE(status.IsOK());
     EXPECT_EQ(status.Category(), StatusCategory::SYSTEM);
     EXPECT_EQ(status.Code(), StatusCode::FAIL);
@@ -240,64 +191,28 @@ TEST(IoTest, SaveFailsWhenParentIsFile)
     EXPECT_FALSE(std::filesystem::exists(target, ec));
 }
 
-TEST(IoTest, LoadFailsForMissingFile)
+TEST_F(IoTest, LoadFailsForMissingFile)
 {
-    ScopedTempDir tempDir;
-    const auto missing = tempDir.path() / "does-not-exist.cal";
+    const auto missing = Path("does-not-exist.json");
 
     CalibrationParameters params{};
-    const auto status = LoadCalibrationParameters(missing.string().c_str(), params);
+    const auto status = Load(missing, params);
 
     EXPECT_FALSE(status.IsOK());
     EXPECT_EQ(status.Category(), StatusCategory::SYSTEM);
     EXPECT_EQ(status.Code(), StatusCode::FAIL);
 }
 
-TEST(IoTest, LoadFailsForInvalidMagic)
+TEST_F(IoTest, SavesZeroRotationAndTranslationAsZeros)
 {
-    ScopedTempDir tempDir;
-    const auto filePath = tempDir.path() / "corrupt-magic.cal";
-    const auto params = MakeSampleParameters();
-    ASSERT_TRUE(SaveCalibrationParameters(filePath.string().c_str(), params).IsOK());
+    CalibrationParameters params;
+    const auto filePath = Path("zero-rt.json");
 
-    std::fstream file(filePath, std::ios::in | std::ios::out | std::ios::binary);
-    ASSERT_TRUE(file.is_open());
-    file.seekp(static_cast<std::streamoff>(0));
-    file.put('X');
-    file.close();
+    ASSERT_TRUE(Save(filePath, params).IsOK());
 
-    CalibrationParameters parsed{};
-    const auto status = LoadCalibrationParameters(filePath.string().c_str(), parsed);
+    CalibrationParameters loaded{};
+    ASSERT_TRUE(Load(filePath, loaded).IsOK());
 
-    EXPECT_FALSE(status.IsOK());
-    EXPECT_EQ(status.Category(), StatusCategory::SYSTEM);
-    EXPECT_EQ(status.Code(), StatusCode::FAIL);
-}
-
-TEST(IoTest, LoadFailsForUnsupportedVersion)
-{
-    ScopedTempDir tempDir;
-    const auto filePath = tempDir.path() / "bad-version.cal";
-    const auto params = MakeSampleParameters();
-    ASSERT_TRUE(SaveCalibrationParameters(filePath.string().c_str(), params).IsOK());
-
-    std::fstream file(filePath, std::ios::in | std::ios::out | std::ios::binary);
-    ASSERT_TRUE(file.is_open());
-    file.seekp(static_cast<std::streamoff>(13));
-
-    std::uint32_t newVersion = 999;
-    if constexpr (std::endian::native != std::endian::little)
-    {
-        newVersion = Byteswap32(newVersion);
-    }
-    file.write(reinterpret_cast<const char *>(&newVersion), sizeof(newVersion));
-    file.close();
-
-    CalibrationParameters parsed{};
-    const auto status = LoadCalibrationParameters(filePath.string().c_str(), parsed);
-
-    EXPECT_FALSE(status.IsOK());
-    EXPECT_EQ(status.Category(), StatusCategory::SYSTEM);
-    EXPECT_EQ(status.Code(), StatusCode::FAIL);
+    EXPECT_EQ(params, loaded);
 }
 } // namespace retinify


### PR DESCRIPTION
Introduce JSON for Modern C++ as a submodule, update the CMake configuration to include the JSON dependency, and enhance the calibration parameters by initializing them with default values and renaming variables for clarity. Improve the test structure accordingly.