### PR TITLE
Improve README formatting for stereo images sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ pipeline.RetrieveDisparity(disparity.ptr<float>(), disparity.step[0]);
 Use this when the stereo images are not rectified.  
 The pipeline undistorts and rectifies the inputs using calibration parameters, performs stereo matching, and outputs disparity, depth, and a 3D point cloud.  
 
-> [!NOTE]
 > If you want to reproject already-rectified stereo images using calibration parameters, set all distortion coefficients to zero.
   
 ```cpp

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ pipeline.RetrieveDisparity(disparity.ptr<float>(), disparity.step[0]);
   <summary>Non-Rectified Stereo Images</summary>
 
 Use this when the stereo images are not rectified.  
-The pipeline undistorts and rectifies the inputs using calibration parameters, performs stereo matching, and outputs disparity, depth, and a 3D point cloud.
+The pipeline undistorts and rectifies the inputs using calibration parameters, performs stereo matching, and outputs disparity, depth, and a 3D point cloud.  
 
 > [!NOTE]
 > If you want to reproject already-rectified stereo images using calibration parameters, set all distortion coefficients to zero.
-
+  
 ```cpp
 #include <retinify/retinify.hpp>
 #include <opencv2/opencv.hpp>


### PR DESCRIPTION
Fix formatting issues in the README related to non-rectified stereo images and remove an unnecessary NOTE block for rectified stereo images.