### PR TITLE
Refactor StereoRectify parameters and remove unused float types

### DIFF
--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -41,34 +41,6 @@ using Mat3x4d = std::array<std::array<double, 4>, 3>;
 using Mat4x4d = std::array<std::array<double, 4>, 4>;
 
 /// @brief
-/// 2D vector (float)
-using Vec2f = std::array<float, 2>;
-
-/// @brief
-/// 3D vector (float)
-using Vec3f = std::array<float, 3>;
-
-/// @brief
-/// 2D point (float)
-using Point2f = std::array<float, 2>;
-
-/// @brief
-/// 3D point (float)
-using Point3f = std::array<float, 3>;
-
-/// @brief
-/// 3x3 matrix (float, row-major)
-using Mat3x3f = std::array<std::array<float, 3>, 3>;
-
-/// @brief
-/// 3x4 matrix (float, row-major)
-using Mat3x4f = std::array<std::array<float, 4>, 3>;
-
-/// @brief
-/// 4x4 matrix (float, row-major)
-using Mat4x4f = std::array<std::array<float, 4>, 4>;
-
-/// @brief
 /// Rectangle structure
 /// @tparam T
 /// Type of the rectangle coordinates and dimensions
@@ -87,10 +59,6 @@ template <typename T> struct Rect2
     /// Height of the rectangle
     T height{0};
 };
-
-/// @brief
-/// 2D rectangle (int)
-using Rect2i = Rect2<std::int32_t>;
 
 /// @brief
 /// 2D rectangle (double)
@@ -293,16 +261,6 @@ struct Distortion
 };
 
 /// @brief
-/// Fisheye distortion model with 4 coefficients (k1, k2, k3, k4)
-struct DistortionFisheye
-{
-    double k1{0};
-    double k2{0};
-    double k3{0};
-    double k4{0};
-};
-
-/// @brief
 /// Stereo camera calibration parameters
 struct CalibrationParameters
 {
@@ -402,8 +360,8 @@ RETINIFY_API auto DistortPoint(const Intrinsics &intrinsics, const Distortion &d
 /// Output projection matrix for the first camera
 /// @param projectionMatrix2
 /// Output projection matrix for the second camera
-/// @param mappingMatrix
-/// Output mapping matrix
+/// @param reprojectionMatrix
+/// Output reprojection matrix
 /// @param alpha
 /// A free scaling parameter that controls cropping after rectification:
 /// 0 keeps only valid pixels (no black borders),
@@ -412,13 +370,7 @@ RETINIFY_API auto DistortPoint(const Intrinsics &intrinsics, const Distortion &d
 /// and -1 applies the default behavior
 /// @return
 /// A Status object that indicates whether the operation was successful
-RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
-                                const Intrinsics &intrinsics2, const Distortion &distortion2, //
-                                const Mat3x3d &rotation, const Vec3d &translation,            //
-                                std::uint32_t imageWidth, std::uint32_t imageHeight,          //
-                                Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
-                                Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
-                                Mat4x4d &mappingMatrix, double alpha) noexcept -> Status;
+RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, const Intrinsics &intrinsics2, const Distortion &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rotation1, Mat3x3d &rotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status;
 
 /// @brief
 /// Initialize undistort and rectify maps for image remapping
@@ -444,11 +396,7 @@ RETINIFY_API auto StereoRectify(const Intrinsics &intrinsics1, const Distortion 
 /// Stride of a row in mapY (in bytes)
 /// @return
 /// A Status object that indicates whether the operation was successful
-RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
-                                          const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
-                                          std::uint32_t imageWidth, std::uint32_t imageHeight,        //
-                                          float *mapX, std::size_t mapXStride,                        //
-                                          float *mapY, std::size_t mapYStride) noexcept -> Status;
+RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status;
 
 /// @brief
 /// Initialize identity maps for undistortion/rectification
@@ -466,7 +414,5 @@ RETINIFY_API auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Di
 /// Image height (in pixels)
 /// @return
 /// A Status object that indicates whether the operation was successful
-RETINIFY_API auto InitIdentityMap(float *mapX, std::size_t mapXStride, //
-                                  float *mapY, std::size_t mapYStride, //
-                                  std::size_t imageWidth, std::size_t imageHeight) noexcept -> Status;
+RETINIFY_API auto InitIdentityMap(float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride, std::size_t imageWidth, std::size_t imageHeight) noexcept -> Status;
 } // namespace retinify

--- a/retinify/src/geometry.cpp
+++ b/retinify/src/geometry.cpp
@@ -348,8 +348,7 @@ enum class BaselineAxis : std::uint8_t
     return Exp(Multiply(cross, scale));
 }
 
-static auto ComputePrincipalPoint(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rectifiedRotation, //
-                                  double newFocalLength, double width, double height) noexcept -> Point2d
+static auto ComputePrincipalPoint(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rectifiedRotation, double newFocalLength, double width, double height) noexcept -> Point2d
 {
     const std::array<Point2d, 4> imageCorners{Point2d{0.0, 0.0}, Point2d{width - 1.0, 0.0}, Point2d{0.0, height - 1.0}, Point2d{width - 1.0, height - 1.0}};
 
@@ -415,10 +414,7 @@ static auto ComputePrincipalPoint(const Intrinsics &intrinsics, const Distortion
     return index == 0 || index == lastIndex;
 }
 
-static void ComputeUndistortRectangles(const Intrinsics &intrinsics, const Distortion &distortion,           //
-                                       const Mat3x3d &rectificationRotation, const Mat3x3d &newCameraMatrix, //
-                                       std::uint32_t imageWidth, std::uint32_t imageHeight,                  //
-                                       Rect2d &inner, Rect2d &outer) noexcept
+static void ComputeUndistortRectangles(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rectificationRotation, const Mat3x3d &newCameraMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, Rect2d &inner, Rect2d &outer) noexcept
 {
     constexpr int kGridSize = 9;
     const int lastIndex = kGridSize - 1;
@@ -527,11 +523,7 @@ static void ComputeUndistortRectangles(const Intrinsics &intrinsics, const Disto
     }
 }
 
-[[nodiscard]] static auto ComputeAlphaScale(const Intrinsics &intrinsics1, const Distortion &distortion1, const Mat3x3d &rectificationRotation1, //
-                                            const Intrinsics &intrinsics2, const Distortion &distortion2, const Mat3x3d &rectificationRotation2, //
-                                            double focalLength, const Point2d &principal1, const Point2d &principal2,                            //
-                                            std::uint32_t imageWidth, std::uint32_t imageHeight,                                                 //
-                                            double alpha) noexcept -> double
+[[nodiscard]] static auto ComputeAlphaScale(const Intrinsics &intrinsics1, const Distortion &distortion1, const Mat3x3d &rectificationRotation1, const Intrinsics &intrinsics2, const Distortion &distortion2, const Mat3x3d &rectificationRotation2, double focalLength, const Point2d &principal1, const Point2d &principal2, std::uint32_t imageWidth, std::uint32_t imageHeight, double alpha) noexcept -> double
 {
     if (alpha < 0.0)
     {
@@ -590,13 +582,7 @@ static void ComputeUndistortRectangles(const Intrinsics &intrinsics, const Disto
 }
 } // namespace
 
-auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, //
-                   const Intrinsics &intrinsics2, const Distortion &distortion2, //
-                   const Mat3x3d &rotation, const Vec3d &translation,            //
-                   std::uint32_t imageWidth, std::uint32_t imageHeight,          //
-                   Mat3x3d &rotation1, Mat3x3d &rotation2,                       //
-                   Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2,       //
-                   Mat4x4d &mappingMatrix, double alpha) noexcept -> Status
+auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1, const Intrinsics &intrinsics2, const Distortion &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rotation1, Mat3x3d &rotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status
 {
     if ((imageWidth == 0U) || (imageHeight == 0U))
     {
@@ -642,23 +628,19 @@ auto StereoRectify(const Intrinsics &intrinsics1, const Distortion &distortion1,
         projectionMatrix2[1][3] = translationOffset;
     }
 
-    mappingMatrix = Mat4x4d{};
-    mappingMatrix[0][0] = 1.0;
-    mappingMatrix[1][1] = 1.0;
-    mappingMatrix[0][3] = -rectifiedPrincipal1[0];
-    mappingMatrix[1][3] = -rectifiedPrincipal1[1];
-    mappingMatrix[2][3] = newFocalLength;
-    mappingMatrix[3][2] = (std::fabs(baselineComponent) > kEpsilon) ? (-1.0 / baselineComponent) : 0.0;
-    mappingMatrix[3][3] = 0.0;
+    reprojectionMatrix = Mat4x4d{};
+    reprojectionMatrix[0][0] = 1.0;
+    reprojectionMatrix[1][1] = 1.0;
+    reprojectionMatrix[0][3] = -rectifiedPrincipal1[0];
+    reprojectionMatrix[1][3] = -rectifiedPrincipal1[1];
+    reprojectionMatrix[2][3] = newFocalLength;
+    reprojectionMatrix[3][2] = (std::fabs(baselineComponent) > kEpsilon) ? (-1.0 / baselineComponent) : 0.0;
+    reprojectionMatrix[3][3] = 0.0;
 
     return Status{};
 }
 
-auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, //
-                             const Mat3x3d &rotation, const Mat3x4d &projectionMatrix,   //
-                             std::uint32_t imageWidth, std::uint32_t imageHeight,        //
-                             float *mapX, std::size_t mapXStride,                        //
-                             float *mapY, std::size_t mapYStride) noexcept -> Status
+auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status
 {
     if (mapX == nullptr || mapY == nullptr)
     {
@@ -736,9 +718,7 @@ auto InitUndistortRectifyMap(const Intrinsics &intrinsics, const Distortion &dis
     return Status{};
 }
 
-auto InitIdentityMap(float *mapX, std::size_t mapXStride, //
-                     float *mapY, std::size_t mapYStride, //
-                     std::size_t imageWidth, std::size_t imageHeight) noexcept -> Status
+auto InitIdentityMap(float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride, std::size_t imageWidth, std::size_t imageHeight) noexcept -> Status
 {
     if (mapX == nullptr || mapY == nullptr)
     {

--- a/retinify/tests/geometry_test.cpp
+++ b/retinify/tests/geometry_test.cpp
@@ -738,9 +738,9 @@ void ExpectStereoRectifyMatchesOpenCVAlpha(double alpha)
     Mat3x3d rotation2{};
     Mat3x4d projectionMatrix1{};
     Mat3x4d projectionMatrix2{};
-    Mat4x4d mappingMatrix{};
+    Mat4x4d reprojectionMatrix{};
 
-    const Status status = StereoRectify(intrinsics1, distortion1, intrinsics2, distortion2, rotation, translation, 960, 720, rotation1, rotation2, projectionMatrix1, projectionMatrix2, mappingMatrix, alpha);
+    const Status status = StereoRectify(intrinsics1, distortion1, intrinsics2, distortion2, rotation, translation, 960, 720, rotation1, rotation2, projectionMatrix1, projectionMatrix2, reprojectionMatrix, alpha);
     ASSERT_TRUE(status.IsOK());
 
     const cv::Mat cameraMatrix1 = ToCvCameraMatrix(intrinsics1);
@@ -780,7 +780,7 @@ void ExpectStereoRectifyMatchesOpenCVAlpha(double alpha)
     expectMatrixRelative(rotation2, expectedR2);
     expectMatrixRelative(projectionMatrix1, expectedP1);
     expectMatrixRelative(projectionMatrix2, expectedP2);
-    expectMatrixRelative(mappingMatrix, expectedQ);
+    expectMatrixRelative(reprojectionMatrix, expectedQ);
 }
 } // namespace
 


### PR DESCRIPTION
Eliminate unused float types for clarity and update parameter names in the StereoRectify function to enhance understanding.