### PR TITLE
Remove open source mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Retinify is an advanced AI-powered stereo vision library designed for robotics. 
 </table>
 
 ## Why retinify?
-- 🌐 **Open Source**: Fully transparent and customizable—adapt the pipeline to your workflow.
 - 🔥 **High Precision**: Delivers real-time, accurate 3D mapping and object recognition from stereo image input.
 - ⚡ **Fast Pipeline**: All necessary computations run seamlessly on the GPU, enabling real-time performance.
 - 🎥 **Camera-Agnostic**: Accepts stereo images from any camera setup, giving you the flexibility to use your own hardware.


### PR DESCRIPTION
Eliminate the reference to open source in the README to better align with project guidelines.