### PR TITLE
Implement NoCopyMove base class to disable copy and move operations

### DIFF
--- a/retinify/include/retinify/constraints.hpp
+++ b/retinify/include/retinify/constraints.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Sensui Yagi. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace retinify
+{
+/// @brief
+/// Base class that disables copy and move operations for derived classes.
+class NoCopyMove
+{
+  protected:
+    NoCopyMove() = default;
+    ~NoCopyMove() = default;
+    NoCopyMove(const NoCopyMove &) = delete;
+    NoCopyMove &operator=(const NoCopyMove &) = delete;
+    NoCopyMove(NoCopyMove &&) = delete;
+    NoCopyMove &operator=(NoCopyMove &&) = delete;
+};
+} // namespace retinify

--- a/retinify/include/retinify/constraints.hpp
+++ b/retinify/include/retinify/constraints.hpp
@@ -13,8 +13,8 @@ class NoCopyMove
     NoCopyMove() = default;
     ~NoCopyMove() = default;
     NoCopyMove(const NoCopyMove &) = delete;
-    NoCopyMove &operator=(const NoCopyMove &) = delete;
+    auto operator=(const NoCopyMove &) -> NoCopyMove & = delete;
     NoCopyMove(NoCopyMove &&) = delete;
-    NoCopyMove &operator=(NoCopyMove &&) = delete;
+    auto operator=(NoCopyMove &&) -> NoCopyMove & = delete;
 };
 } // namespace retinify

--- a/retinify/include/retinify/logging.hpp
+++ b/retinify/include/retinify/logging.hpp
@@ -49,7 +49,7 @@ RETINIFY_API void SetLogLevel(LogLevel level) noexcept;
 
 /// @brief
 /// Logging source location options
-enum class LogLocation
+enum class LogLocation : std::uint8_t
 {
     /// @brief
     /// No source location

--- a/retinify/include/retinify/pipeline.hpp
+++ b/retinify/include/retinify/pipeline.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "retinify/constraints.hpp"
 #include "retinify/geometry.hpp"
 #include "retinify/status.hpp"
 
@@ -41,15 +42,11 @@ enum class DepthMode : std::uint8_t
 
 /// @brief
 /// A `retinify::Pipeline` provides an interface for running a stereo matching
-class RETINIFY_API Pipeline
+class RETINIFY_API Pipeline : private NoCopyMove
 {
   public:
     Pipeline() noexcept;
     ~Pipeline() noexcept;
-    Pipeline(const Pipeline &) = delete;
-    auto operator=(const Pipeline &) noexcept -> Pipeline & = delete;
-    Pipeline(Pipeline &&) noexcept = delete;
-    auto operator=(Pipeline &&) noexcept -> Pipeline & = delete;
 
     /// @brief
     /// Initializes the stereo matching pipeline with the given image dimensions

--- a/retinify/src/mat.hpp
+++ b/retinify/src/mat.hpp
@@ -6,6 +6,7 @@
 #include "stream.hpp"
 
 #include "retinify/attributes.hpp"
+#include "retinify/constraints.hpp"
 #include "retinify/status.hpp"
 
 #include <array>
@@ -23,15 +24,11 @@ enum class MatLocation
     HOST,
 };
 
-class RETINIFY_API Mat
+class RETINIFY_API Mat : public NoCopyMove
 {
   public:
     Mat() noexcept = default;
     ~Mat() noexcept;
-    Mat(const Mat &) = delete;
-    auto operator=(const Mat &) -> Mat & = delete;
-    Mat(Mat &&other) noexcept = delete;
-    auto operator=(Mat &&other) noexcept -> Mat & = delete;
     [[nodiscard]] auto Allocate(std::size_t rows, std::size_t cols, std::size_t channels, std::size_t bytesPerElement, MatLocation location) noexcept -> Status;
     [[nodiscard]] auto Free() noexcept -> Status;
     [[nodiscard]] auto Upload(const void *hostData, std::size_t hostStride, Stream &stream) const noexcept -> Status;

--- a/retinify/src/session.hpp
+++ b/retinify/src/session.hpp
@@ -6,6 +6,7 @@
 #include "mat.hpp"
 #include "stream.hpp"
 
+#include "retinify/constraints.hpp"
 #include "retinify/status.hpp"
 
 #include <array>
@@ -30,15 +31,11 @@ constexpr int kEngineOptWidth = 640;
 constexpr int kEngineMaxHeight = 720;
 constexpr int kEngineMaxWidth = 1280;
 
-class RETINIFY_API Session
+class RETINIFY_API Session : public NoCopyMove
 {
   public:
     Session() noexcept = default;
     ~Session() noexcept = default;
-    Session(const Session &) = delete;
-    auto operator=(const Session &) noexcept -> Session & = delete;
-    Session(Session &&other) noexcept = delete;
-    auto operator=(Session &&other) noexcept -> Session & = delete;
     [[nodiscard]] auto Initialize(const char *modelPath) noexcept -> Status;
     [[nodiscard]] auto BindInput(const char *name, const Mat &mat) const noexcept -> Status;
     [[nodiscard]] auto BindOutput(const char *name, const Mat &mat) const noexcept -> Status;

--- a/retinify/src/stream.hpp
+++ b/retinify/src/stream.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "retinify/attributes.hpp"
+#include "retinify/constraints.hpp"
 #include "retinify/status.hpp"
 
 #ifdef BUILD_WITH_TENSORRT
@@ -15,15 +16,11 @@
 
 namespace retinify
 {
-class RETINIFY_API Stream
+class RETINIFY_API Stream : public NoCopyMove
 {
   public:
     Stream() noexcept = default;
     ~Stream() noexcept;
-    Stream(const Stream &) = delete;
-    auto operator=(const Stream &) noexcept -> Stream & = delete;
-    Stream(Stream &&) noexcept = delete;
-    auto operator=(Stream &&) noexcept -> Stream & = delete;
     [[nodiscard]] auto Create() noexcept -> Status;
     [[nodiscard]] auto Destroy() noexcept -> Status;
     [[nodiscard]] auto Synchronize() const noexcept -> Status;


### PR DESCRIPTION
Introduce a base class that prevents copy and move semantics for derived classes, enhancing memory safety and resource management in the pipeline, matrix, session, and stream classes.