### PR TITLE
Change Pipeline class inheritance to public

### DIFF
--- a/retinify/include/retinify/pipeline.hpp
+++ b/retinify/include/retinify/pipeline.hpp
@@ -42,7 +42,7 @@ enum class DepthMode : std::uint8_t
 
 /// @brief
 /// A `retinify::Pipeline` provides an interface for running a stereo matching
-class RETINIFY_API Pipeline : private NoCopyMove
+class RETINIFY_API Pipeline : public NoCopyMove
 {
   public:
     Pipeline() noexcept;


### PR DESCRIPTION
Modify the inheritance of the Pipeline class from private to public to allow for broader accessibility.