### PR TITLE
Refactor DistortionParameters to DistortionCoefficients

### DIFF
--- a/docs/content/calibration.md
+++ b/docs/content/calibration.md
@@ -5,13 +5,13 @@
 
 retinify::CalibrationParameters supports the pinhole camera model.
 
-- Intrinsic Parameters: retinify::PinholeIntrinsics
+- Pinhole Intrinsics: retinify::PinholeIntrinsics
 
   - Focal lengths: `fx`, `fy`
   - Principal point: `cx`, `cy`
   - Skew coefficient: `skew`
 
-- Distortion Coefficients: retinify::DistortionParameters
+- Distortion Coefficients: retinify::DistortionCoefficients
 
   - Radial distortion coefficients: `k1`, `k2`, `k3`, `k4`, `k5`, `k6`
   - Tangential distortion coefficients: `p1`, `p2`

--- a/retinify/include/retinify/geometry.hpp
+++ b/retinify/include/retinify/geometry.hpp
@@ -236,7 +236,7 @@ struct PinholeIntrinsics
 
 /// @brief
 /// Rational distortion model with 8 coefficients: (k1, k2, p1, p2, k3, k4, k5, k6)
-struct DistortionParameters
+struct DistortionCoefficients
 {
     double k1{0};
     double k2{0};
@@ -247,7 +247,7 @@ struct DistortionParameters
     double k5{0};
     double k6{0};
 
-    [[nodiscard]] auto operator==(const DistortionParameters &other) const noexcept -> bool
+    [[nodiscard]] auto operator==(const DistortionCoefficients &other) const noexcept -> bool
     {
         return k1 == other.k1 && //
                k2 == other.k2 && //
@@ -268,14 +268,14 @@ struct CalibrationParameters
     /// Pinhole intrinsics for the left camera
     PinholeIntrinsics leftIntrinsics{};
     /// @brief
-    /// Distortion parameters for the left camera
-    DistortionParameters leftDistortion{};
+    /// Distortion coefficients for the left camera
+    DistortionCoefficients leftDistortion{};
     /// @brief
     /// Pinhole intrinsics for the right camera
     PinholeIntrinsics rightIntrinsics{};
     /// @brief
-    /// Distortion parameters for the right camera
-    DistortionParameters rightDistortion{};
+    /// Distortion coefficients for the right camera
+    DistortionCoefficients rightDistortion{};
     /// @brief
     /// Rotation matrix
     Mat3x3d rotation{};
@@ -311,28 +311,28 @@ struct CalibrationParameters
 };
 
 /// @brief
-/// Undistort a 2D point using the given camera intrinsics and distortion parameters
+/// Undistort a 2D point using the given camera intrinsics and distortion coefficients
 /// @param intrinsics
 /// Camera intrinsic parameters
 /// @param distortion
-/// Distortion parameters
+/// Distortion coefficients
 /// @param point
 /// Distorted 2D point (in pixel coordinates)
 /// @return
 /// Undistorted 2D point (normalized image coordinates)
-RETINIFY_API auto UndistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Point2d &point) noexcept -> Point2d;
+RETINIFY_API auto UndistortPoint(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Point2d &point) noexcept -> Point2d;
 
 /// @brief
-/// Distort a normalized 2D point using the given camera intrinsics and distortion parameters
+/// Distort a normalized 2D point using the given camera intrinsics and distortion coefficients
 /// @param intrinsics
 /// Camera intrinsic parameters
 /// @param distortion
-/// Distortion parameters
+/// Distortion coefficients
 /// @param point
 /// Undistorted 2D point (normalized image coordinates)
 /// @return
 /// Distorted 2D point (in pixel coordinates)
-RETINIFY_API auto DistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Point2d &point) noexcept -> Point2d;
+RETINIFY_API auto DistortPoint(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Point2d &point) noexcept -> Point2d;
 
 /// @brief
 /// Perform stereo rectification for a pair of cameras
@@ -370,14 +370,14 @@ RETINIFY_API auto DistortPoint(const PinholeIntrinsics &intrinsics, const Distor
 /// and -1 applies the default behavior
 /// @return
 /// A Status object that indicates whether the operation was successful
-RETINIFY_API auto StereoRectify(const PinholeIntrinsics &intrinsics1, const DistortionParameters &distortion1, const PinholeIntrinsics &intrinsics2, const DistortionParameters &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rotation1, Mat3x3d &rotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status;
+RETINIFY_API auto StereoRectify(const PinholeIntrinsics &intrinsics1, const DistortionCoefficients &distortion1, const PinholeIntrinsics &intrinsics2, const DistortionCoefficients &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rotation1, Mat3x3d &rotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status;
 
 /// @brief
 /// Initialize undistort and rectify maps for image remapping
 /// @param intrinsics
 /// Camera intrinsics
 /// @param distortion
-/// Distortion parameters
+/// Distortion coefficients
 /// @param rotation
 /// Rectification rotation
 /// @param projectionMatrix
@@ -396,7 +396,7 @@ RETINIFY_API auto StereoRectify(const PinholeIntrinsics &intrinsics1, const Dist
 /// Stride of a row in mapY (in bytes)
 /// @return
 /// A Status object that indicates whether the operation was successful
-RETINIFY_API auto InitUndistortRectifyMap(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status;
+RETINIFY_API auto InitUndistortRectifyMap(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status;
 
 /// @brief
 /// Initialize identity maps for undistortion/rectification

--- a/retinify/src/geometry.cpp
+++ b/retinify/src/geometry.cpp
@@ -290,7 +290,7 @@ enum class BaselineAxis : std::uint8_t
     return Exp(Multiply(cross, scale));
 }
 
-[[nodiscard]] auto ComputePrincipalPoint(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Mat3x3d &rectifiedRotation, double newFocalLength, double width, double height) noexcept -> Point2d
+[[nodiscard]] auto ComputePrincipalPoint(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Mat3x3d &rectifiedRotation, double newFocalLength, double width, double height) noexcept -> Point2d
 {
     const std::array<Point2d, 4> imageCorners{Point2d{0.0, 0.0}, Point2d{width - 1.0, 0.0}, Point2d{0.0, height - 1.0}, Point2d{width - 1.0, height - 1.0}};
 
@@ -358,7 +358,7 @@ constexpr double kInfinity = std::numeric_limits<double>::infinity();
     return index == 0 || index == lastIndex;
 }
 
-auto ComputeRectifiedInnerOuterRectangles(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Mat3x3d &rectifiedRotation, const Mat3x3d &newCameraMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, Rect2d &inner, Rect2d &outer) noexcept -> void
+auto ComputeRectifiedInnerOuterRectangles(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Mat3x3d &rectifiedRotation, const Mat3x3d &newCameraMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, Rect2d &inner, Rect2d &outer) noexcept -> void
 {
     constexpr int kGridSize = 9;
     constexpr int kLastIndex = kGridSize - 1;
@@ -465,7 +465,7 @@ auto ComputeRectifiedInnerOuterRectangles(const PinholeIntrinsics &intrinsics, c
     }
 }
 
-[[nodiscard]] auto ComputeRectifiedFocalLengthScale(const PinholeIntrinsics &intrinsics1, const DistortionParameters &distortion1, const Mat3x3d &rectifiedRotation1, const PinholeIntrinsics &intrinsics2, const DistortionParameters &distortion2, const Mat3x3d &rectifiedRotation2, double focalLength, const Point2d &principalPoint1, const Point2d &principalPoint2, std::uint32_t imageWidth, std::uint32_t imageHeight, double alpha) noexcept -> double
+[[nodiscard]] auto ComputeRectifiedFocalLengthScale(const PinholeIntrinsics &intrinsics1, const DistortionCoefficients &distortion1, const Mat3x3d &rectifiedRotation1, const PinholeIntrinsics &intrinsics2, const DistortionCoefficients &distortion2, const Mat3x3d &rectifiedRotation2, double focalLength, const Point2d &principalPoint1, const Point2d &principalPoint2, std::uint32_t imageWidth, std::uint32_t imageHeight, double alpha) noexcept -> double
 {
     if (alpha < 0.0)
     {
@@ -524,7 +524,7 @@ auto ComputeRectifiedInnerOuterRectangles(const PinholeIntrinsics &intrinsics, c
 }
 } // namespace
 
-auto UndistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Point2d &point) noexcept -> Point2d
+auto UndistortPoint(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Point2d &point) noexcept -> Point2d
 {
     const double inverseFocalX = Reciprocal(intrinsics.fx, 1.0);
     const double inverseFocalY = Reciprocal(intrinsics.fy, 1.0);
@@ -556,7 +556,7 @@ auto UndistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParamet
     return {undistortedX, undistortedY};
 }
 
-auto DistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Point2d &point) noexcept -> Point2d
+auto DistortPoint(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Point2d &point) noexcept -> Point2d
 {
     const double undistortedX = point[0];
     const double undistortedY = point[1];
@@ -579,7 +579,7 @@ auto DistortPoint(const PinholeIntrinsics &intrinsics, const DistortionParameter
     return {distortedX * intrinsics.fx + intrinsics.cx, distortedY * intrinsics.fy + intrinsics.cy};
 }
 
-auto StereoRectify(const PinholeIntrinsics &intrinsics1, const DistortionParameters &distortion1, const PinholeIntrinsics &intrinsics2, const DistortionParameters &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rectifiedRotation1, Mat3x3d &rectifiedRotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status
+auto StereoRectify(const PinholeIntrinsics &intrinsics1, const DistortionCoefficients &distortion1, const PinholeIntrinsics &intrinsics2, const DistortionCoefficients &distortion2, const Mat3x3d &rotation, const Vec3d &translation, std::uint32_t imageWidth, std::uint32_t imageHeight, Mat3x3d &rectifiedRotation1, Mat3x3d &rectifiedRotation2, Mat3x4d &projectionMatrix1, Mat3x4d &projectionMatrix2, Mat4x4d &reprojectionMatrix, double alpha) noexcept -> Status
 {
     if ((imageWidth == 0U) || (imageHeight == 0U))
     {
@@ -636,7 +636,7 @@ auto StereoRectify(const PinholeIntrinsics &intrinsics1, const DistortionParamet
     return Status{};
 }
 
-auto InitUndistortRectifyMap(const PinholeIntrinsics &intrinsics, const DistortionParameters &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status
+auto InitUndistortRectifyMap(const PinholeIntrinsics &intrinsics, const DistortionCoefficients &distortion, const Mat3x3d &rotation, const Mat3x4d &projectionMatrix, std::uint32_t imageWidth, std::uint32_t imageHeight, float *mapX, std::size_t mapXStride, float *mapY, std::size_t mapYStride) noexcept -> Status
 {
     if (mapX == nullptr || mapY == nullptr)
     {

--- a/retinify/src/io.cpp
+++ b/retinify/src/io.cpp
@@ -100,7 +100,7 @@ template <typename T> [[nodiscard]] auto ReadIntegral(const nlohmann::json &obj,
             {kKeySkew, intrinsics.skew}};
 }
 
-[[nodiscard]] auto SerializeDistortion(const DistortionParameters &distortion) -> nlohmann::json
+[[nodiscard]] auto SerializeDistortion(const DistortionCoefficients &distortion) -> nlohmann::json
 {
     return {{kKeyK1, distortion.k1}, //
             {kKeyK2, distortion.k2}, //
@@ -140,7 +140,7 @@ template <typename T> [[nodiscard]] auto ReadIntegral(const nlohmann::json &obj,
            ReadNumber(value, kKeySkew, intrinsics.skew);
 }
 
-[[nodiscard]] auto DeserializeDistortion(const nlohmann::json &value, DistortionParameters &distortion) -> bool
+[[nodiscard]] auto DeserializeDistortion(const nlohmann::json &value, DistortionCoefficients &distortion) -> bool
 {
     if (!value.is_object())
     {

--- a/retinify/tests/geometry_test.cpp
+++ b/retinify/tests/geometry_test.cpp
@@ -259,7 +259,7 @@ TEST(GeometryTest, LogHandlesPiRotation)
 TEST(GeometryTest, UndistortPointWithFiveCoefficients)
 {
     const retinify::PinholeIntrinsics intrinsics{500.0, 480.0, 320.0, 240.0, 0.0};
-    const retinify::DistortionParameters distortion{0.12, -0.05, 0.001, 0.0005, 0.03};
+    const retinify::DistortionCoefficients distortion{0.12, -0.05, 0.001, 0.0005, 0.03};
 
     const retinify::Point2d idealPixel{0.05, -0.04};
     const retinify::Point2d distortedPixel = DistortPoint(intrinsics, distortion, idealPixel);
@@ -273,7 +273,7 @@ TEST(GeometryTest, UndistortPointWithFiveCoefficients)
 TEST(GeometryTest, UndistortPointWithEightCoefficients)
 {
     const retinify::PinholeIntrinsics intrinsics{500.0, 480.0, 320.0, 240.0, 0.0};
-    const retinify::DistortionParameters distortion{0.08, -0.03, -0.0007, 0.0004, 0.015, 0.005, -0.002, 0.001};
+    const retinify::DistortionCoefficients distortion{0.08, -0.03, -0.0007, 0.0004, 0.015, 0.005, -0.002, 0.001};
 
     const retinify::Point2d idealPixel{-0.06, 0.045};
     const retinify::Point2d distortedPixel = DistortPoint(intrinsics, distortion, idealPixel);
@@ -288,7 +288,7 @@ TEST(GeometryTest, StereoRectifyIdealRig)
 {
     const retinify::PinholeIntrinsics primaryIntrinsics{500.0, 500.0, 320.0, 240.0, 0.0};
     const retinify::PinholeIntrinsics secondaryIntrinsics{500.0, 500.0, 320.0, 240.0, 0.0};
-    const retinify::DistortionParameters noDistortion{};
+    const retinify::DistortionCoefficients noDistortion{};
 
     const retinify::Mat3x3d rotationMatrix = Identity();
     const retinify::Vec3d translationVector{0.1, 0.0, 0.0};
@@ -334,8 +334,8 @@ TEST(GeometryTest, StereoRectifyHorizontalBaseline)
 {
     const retinify::PinholeIntrinsics K1{620.0, 590.0, 310.0, 245.0, 0.0};
     const retinify::PinholeIntrinsics K2{600.0, 575.0, 305.0, 250.0, 0.0};
-    const retinify::DistortionParameters D1{0.01, -0.005, 0.0005, -0.0003, 0.001, 0.0002, -1e-4, 5e-5};
-    const retinify::DistortionParameters D2{-0.008, 0.004, -0.0004, 8e-4, -0.0009, 0.0003, 2e-4, -6e-5};
+    const retinify::DistortionCoefficients D1{0.01, -0.005, 0.0005, -0.0003, 0.001, 0.0002, -1e-4, 5e-5};
+    const retinify::DistortionCoefficients D2{-0.008, 0.004, -0.0004, 8e-4, -0.0009, 0.0003, 2e-4, -6e-5};
 
     const retinify::Mat3x3d rotationMatrix = retinify::Exp({0.1, -0.05, 0.07});
     const retinify::Vec3d translationVector{0.12, 0.03, -0.02};
@@ -386,8 +386,8 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
 {
     const retinify::PinholeIntrinsics K1{580.0, 615.0, 315.0, 255.0, 0.0};
     const retinify::PinholeIntrinsics K2{590.0, 605.0, 320.0, 248.0, 0.0};
-    const retinify::DistortionParameters D1{-0.006, 0.003, -0.0002, 0.0004, -0.0007, 1e-4, -5e-5, 2e-5};
-    const retinify::DistortionParameters D2{0.005, -0.002, 3e-4, -4e-4, 8e-4, -2e-4, 7e-5, -3e-5};
+    const retinify::DistortionCoefficients D1{-0.006, 0.003, -0.0002, 0.0004, -0.0007, 1e-4, -5e-5, 2e-5};
+    const retinify::DistortionCoefficients D2{0.005, -0.002, 3e-4, -4e-4, 8e-4, -2e-4, 7e-5, -3e-5};
 
     const retinify::Mat3x3d rotationMatrix = retinify::Exp({-0.04, 0.02, 0.05});
     const retinify::Vec3d translationVector{0.015, 0.2, -0.025};
@@ -437,7 +437,7 @@ TEST(GeometryTest, StereoRectifyVerticalBaseline)
 TEST(GeometryTest, StereoRectifyRejectsZeroDimensions)
 {
     const PinholeIntrinsics intrinsics{500.0, 500.0, 320.0, 240.0, 0.0};
-    const DistortionParameters distortion{};
+    const DistortionCoefficients distortion{};
     const Mat3x3d rotation = Identity();
     const Vec3d translation{0.1, 0.0, 0.0};
     Mat3x3d rotation1{};
@@ -455,7 +455,7 @@ TEST(GeometryTest, StereoRectifyRejectsZeroDimensions)
 TEST(GeometryTest, InitUndistortRectifyMapIdentity)
 {
     const PinholeIntrinsics intrinsics{1.0, 1.0, 0.0, 0.0, 0.0};
-    const DistortionParameters distortion{};
+    const DistortionCoefficients distortion{};
     const Mat3x3d rectificationRotation = Identity();
 
     Mat3x4d projection{};
@@ -499,7 +499,7 @@ TEST(GeometryTest, InitUndistortRectifyMapIdentity)
 TEST(GeometryTest, InitUndistortRectifyMapRotatedCamera)
 {
     const PinholeIntrinsics intrinsics{4.0, 5.0, 3.0, 2.0, 0.1};
-    const DistortionParameters distortion{};
+    const DistortionCoefficients distortion{};
     const Mat3x3d rectificationRotation{{{0.0, -1.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.0, 1.0}}};
 
     Mat3x4d projection{};
@@ -552,7 +552,7 @@ TEST(GeometryTest, InitUndistortRectifyMapRotatedCamera)
 TEST(GeometryTest, InitUndistortRectifyMapAppliesDistortion)
 {
     const PinholeIntrinsics intrinsics{500.0, 520.0, 320.0, 240.0, 0.0};
-    const DistortionParameters distortion{0.05, -0.01, 0.001, -0.0004, 0.0005, -0.0002, 0.0001, -5e-5};
+    const DistortionCoefficients distortion{0.05, -0.01, 0.001, -0.0004, 0.0005, -0.0002, 0.0001, -5e-5};
     const Mat3x3d rectificationRotation = Identity();
 
     Mat3x4d projection{};
@@ -602,7 +602,7 @@ TEST(GeometryTest, InitUndistortRectifyMapAppliesDistortion)
 TEST(GeometryTest, InitUndistortRectifyMapRejectsInvalidArgs)
 {
     const PinholeIntrinsics intrinsics{400.0, 410.0, 200.0, 150.0, 0.0};
-    const DistortionParameters distortion{};
+    const DistortionCoefficients distortion{};
     const Mat3x3d rotation = Identity();
     Mat3x4d projection{};
     projection[0][0] = 1.0;
@@ -648,7 +648,7 @@ auto ToCvCameraMatrix(const PinholeIntrinsics &intrinsics) -> cv::Mat
     return cameraMatrix;
 }
 
-auto ToCvDistCoeffs(const DistortionParameters &distortion) -> cv::Mat
+auto ToCvDistCoeffs(const DistortionCoefficients &distortion) -> cv::Mat
 {
     cv::Mat distCoeffs = cv::Mat::zeros(1, 8, CV_64F);
     distCoeffs.at<double>(0, 0) = distortion.k1;
@@ -728,8 +728,8 @@ void ExpectStereoRectifyMatchesOpenCVAlpha(double alpha)
 {
     const PinholeIntrinsics intrinsics1{615.0, 605.0, 321.5, 242.0, 0.0};
     const PinholeIntrinsics intrinsics2{590.0, 600.0, 318.0, 239.5, 0.0};
-    const DistortionParameters distortion1{0.011, -0.004, 5e-4, -3e-4, 7e-4, -2e-4, 1e-4, -5e-5};
-    const DistortionParameters distortion2{-0.009, 0.0035, -4e-4, 2.5e-4, -6e-4, 1.5e-4, -8e-5, 4e-5};
+    const DistortionCoefficients distortion1{0.011, -0.004, 5e-4, -3e-4, 7e-4, -2e-4, 1e-4, -5e-5};
+    const DistortionCoefficients distortion2{-0.009, 0.0035, -4e-4, 2.5e-4, -6e-4, 1.5e-4, -8e-5, 4e-5};
 
     const Mat3x3d rotation = Exp({0.08, -0.06, 0.04});
     const Vec3d translation{0.12, 0.035, -0.018};
@@ -807,7 +807,7 @@ TEST(GeometryTest, StereoRectifyMatchesOpenCVAlphaOne)
 TEST(GeometryTest, InitUndistortRectifyMapMatchesOpenCV)
 {
     const PinholeIntrinsics intrinsics{612.5, 598.0, 322.0, 241.5, 0.0};
-    const DistortionParameters distortion{-0.013, 0.0045, -6e-4, 3.5e-4, -7.5e-4, 2e-4, -1.1e-4, 6e-5};
+    const DistortionCoefficients distortion{-0.013, 0.0045, -6e-4, 3.5e-4, -7.5e-4, 2e-4, -1.1e-4, 6e-5};
 
     const Mat3x3d rectificationRotation = Exp({-0.02, 0.015, 0.03});
     Mat3x4d projection{};


### PR DESCRIPTION
Renamed `DistortionParameters` to `DistortionCoefficients` for consistency across the codebase. Updated related documentation and function signatures accordingly.